### PR TITLE
Fix `metadata_add_location`

### DIFF
--- a/R/setup.R
+++ b/R/setup.R
@@ -276,8 +276,11 @@ metadata_add_locations <- function(dataset_id, location_data) {
 
   cat(
     sprintf("Following locations added to metadata for %s: %s\n\twith variables %s.\n\tPlease complete information in %s.\n\n",
-    dataset_id, crayon::red(paste(names(metadata$locations), collapse = ", ")),
-    crayon::red(paste(keep, collapse = ", ")), dataset_id %>% metadata_path_dataset_id())
+      dataset_id,
+      crayon::red(paste(names(metadata$locations), collapse = ", ")),
+      crayon::red(paste(keep, collapse = ", ")),
+      dataset_id %>% metadata_path_dataset_id()
+    )
   )
 
   write_metadata_dataset(metadata, dataset_id)

--- a/R/setup.R
+++ b/R/setup.R
@@ -254,17 +254,18 @@ metadata_add_traits <- function(dataset_id) {
 #' }
 metadata_add_locations <- function(dataset_id, location_data) {
 
+  vars <- names(location_data)
+
   # read metadata
   metadata <- read_metadata_dataset(dataset_id)
 
   # Choose column for location_name
-  location_name <- metadata_user_select_column("location_name", names(location_data))
+  location_name <- metadata_user_select_column("location_name", vars)
 
   # From remaining variables, choose those to keep
-  location_sub <- location_data %>% dplyr::select(-dplyr::all_of(c(location_name)))
   keep <- metadata_user_select_names(
     paste("Indicate all columns you wish to keep as distinct location_properties in ",
-    dataset_id), names(location_sub)
+    dataset_id), vars[vars != location_name]
   )
 
   # Save and notify

--- a/R/setup.R
+++ b/R/setup.R
@@ -261,15 +261,17 @@ metadata_add_locations <- function(dataset_id, location_data) {
   location_name <- metadata_user_select_column("location_name", names(location_data))
 
   # From remaining variables, choose those to keep
-  location_sub <- dplyr::select(dplyr::all_of(c("location_data"), -!!location_name))
+  location_sub <- location_data %>% dplyr::select(-dplyr::all_of(c(location_name)))
   keep <- metadata_user_select_names(
     paste("Indicate all columns you wish to keep as distinct location_properties in ",
     dataset_id), names(location_sub)
   )
 
   # Save and notify
-  metadata$locations <- dplyr::select(dplyr::all_of(c("location_data"), tidyr::one_of(keep))) %>%
-            split(location_data[[location_name]]) %>% lapply(as.list)
+  metadata$locations <- location_data %>%
+    dplyr::select(dplyr::all_of(keep)) %>%
+    split(location_data[[location_name]]) %>%
+    lapply(as.list)
 
   cat(
     sprintf("Following locations added to metadata for %s: %s\n\twith variables %s.\n\tPlease complete information in %s.\n\n",

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -102,13 +102,6 @@ test_that("metadata_add_source_bibtex is working", {
   expect_equal(read_metadata("data/Test_2022/metadata.yml")$source$primary$journal, "Journal of Ecology")
 })
 
-test_that("metadata_add_locations is working", {
-  locations <- read_csv("data/Test_2022/data.csv") %>%
-    select(site) %>% distinct() %>%
-    mutate(latitude = 1, longitude = 2, elevation = 100)
-  expect_no_error(metadata_add_locations(dataset_id = "Test_2022", locations))
-})
-
 test_that("metadata_add_substitution is working", {
   expect_silent(
     suppressMessages(

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -102,6 +102,13 @@ test_that("metadata_add_source_bibtex is working", {
   expect_equal(read_metadata("data/Test_2022/metadata.yml")$source$primary$journal, "Journal of Ecology")
 })
 
+test_that("metadata_add_locations is working", {
+  locations <- read_csv("data/Test_2022/data.csv") %>%
+    select(site) %>% distinct() %>%
+    mutate(latitude = 1, longitude = 2, elevation = 100)
+  expect_no_error(metadata_add_locations(dataset_id = "Test_2022", locations))
+})
+
 test_that("metadata_add_substitution is working", {
   expect_silent(
     suppressMessages(
@@ -233,7 +240,7 @@ test_that("reports and plots are produced", {
   )
 })
 
-testthat::test_that("test_data is working", {
+testthat::test_that("dataset_test is working", {
   expect_silent(
     out <- dataset_test("Test_2022", reporter = testthat::SilentReporter))
   expect_in(


### PR DESCRIPTION
Arising from issue https://github.com/traitecoevo/traits.build/issues/39:
Issue probably arose from adding in `tidyselect` terms `all_of` and `any_of` a while back. I'm assuming during this process that the first argument of select (`.data`) was erroneously put into an `all_of` argument. 

I did some research on the syntax `!!` and I'm not sure if it's necessary here @dfalster. I can't think of any instances where simply using `-dplyr::all_of(c(location_name))` wouldn't work but please correct me if I'm wrong! 