### PR TITLE
Edits to `metadata_add_locations`

### DIFF
--- a/R/setup.R
+++ b/R/setup.R
@@ -360,10 +360,18 @@ metadata_add_locations <- function(dataset_id, location_data, user_responses = N
   }
 
   # Save and notify
-
   location_data <-  location_data %>%
     dplyr::select(dplyr::all_of(c(location_name, keep))) %>%
     distinct()
+
+  if (is.na(keep[1])) {
+    location_data <-  location_data %>%
+    dplyr::mutate(
+      `latitude (deg)` = NA_character_,
+      `longitude (deg)` = NA_character_,
+      `desscription` = NA_character_,
+      )
+  }
   
   metadata$locations <- location_data %>%
     dplyr::select(-location_name) %>%  
@@ -376,7 +384,7 @@ metadata_add_locations <- function(dataset_id, location_data, user_responses = N
         red("with variables ") %+% green("'%s'\n\t") %+% red("Please complete information in %s"),
       blue(dataset_id),
       paste(names(metadata$locations), collapse = "', '"),
-      paste(keep, collapse = "', '"),
+      ifelse(is.na(keep[1]),"latitude (deg)', 'longitude (deg)', 'description",paste(keep, collapse = "', '")),
       blue(dataset_id %>% metadata_path_dataset_id())
     )
   )

--- a/R/setup.R
+++ b/R/setup.R
@@ -364,6 +364,7 @@ metadata_add_locations <- function(dataset_id, location_data, user_responses = N
     dplyr::select(dplyr::all_of(c(location_name, keep))) %>%
     distinct()
 
+  # If user didn't select any variables to keep, so add defaults
   if (is.na(keep[1])) {
     location_data <-  location_data %>%
     dplyr::mutate(

--- a/R/setup.R
+++ b/R/setup.R
@@ -369,7 +369,7 @@ metadata_add_locations <- function(dataset_id, location_data, user_responses = N
     dplyr::mutate(
       `latitude (deg)` = NA_character_,
       `longitude (deg)` = NA_character_,
-      `desscription` = NA_character_,
+      `description` = NA_character_,
       )
   }
   

--- a/R/setup.R
+++ b/R/setup.R
@@ -360,8 +360,13 @@ metadata_add_locations <- function(dataset_id, location_data, user_responses = N
   }
 
   # Save and notify
+
+  location_data <-  location_data %>%
+    dplyr::select(dplyr::all_of(c(location_name, keep))) %>%
+    distinct()
+  
   metadata$locations <- location_data %>%
-    dplyr::select(dplyr::all_of(keep)) %>%
+    dplyr::select(-location_name) %>%  
     split(location_data[[location_name]]) %>%
     lapply(as.list)
 
@@ -375,6 +380,18 @@ metadata_add_locations <- function(dataset_id, location_data, user_responses = N
       blue(dataset_id %>% metadata_path_dataset_id())
     )
   )
+  
+  if (nrow(location_data) != length(unique(location_data[[location_name]]))) {
+  message(
+    sprintf(
+      red("WARNING: The number of unique location names (%s), is less than the number rows of location data to add (%s). ") %+% 
+        red("Manual editing is REQUIRED in %s to ensure each location has a single value for each location property."),
+      blue(length(unique(location_data[[location_name]]))),
+      blue(nrow(location_data)),
+      blue(dataset_id %>% metadata_path_dataset_id())
+    )
+  )
+  }
 
   write_metadata_dataset(metadata, dataset_id)
   return(invisible(metadata))


### PR DESCRIPTION
A few changes to `metadata_add_locations`:

- `distinct()` across the columns selected for the `location_name` and `location_properties` is used to ensure only a single instance of each row of location data is read in (solves issue #46)

- if the number of unique location names is less than the number of rows of data retained, a warning is issued that one or more sites have multiple values per location property

- this also results in an error in `dataset_test` (not new) - but now some errors will be avoided (through the use of distinct() ) and others will yield a warning during input

- If you only select a location name and no location_properties, then latitude, longitude and description are automatically added as blank properties to all unique location names. This now means you can add location names directly from the data file if the remaining information needs to be added manually anyway (solves issue #45)