### PR TITLE
Fix unit conversions warning

### DIFF
--- a/R/process.R
+++ b/R/process.R
@@ -1196,6 +1196,7 @@ process_convert_units <- function(data, definitions, unit_conversion_functions) 
   # Split by unique unit conversions, to allow for as few calls as possible
   data <- data %>%
     dplyr::group_by(.data$ucn, .data$to_convert) %>%
+    dplyr::rowwise() %>%
     dplyr::mutate(
       # Standard conversion
       value = ifelse(.data$to_convert == TRUE &                     # Value requires conversion
@@ -1203,8 +1204,8 @@ process_convert_units <- function(data, definitions, unit_conversion_functions) 
                       !is.na(.data$value),                          # Value not NA - the full matrix from data.csv file is still in data table
                       f_standard(.data$value, .data$ucn[1]),        # Convert value to appropriate units
                      .data$value),                                  # If conditions not met, keep original value
-      # Value is a range of bin
-      value = ifelse(.data$to_convert == TRUE  &                    # Value requires conversion
+      # Value is a range or bin
+      value = ifelse(.data$to_convert == TRUE &                    # Value requires conversion
                       .data$value_type %in% c("bin", "range") &     # `value_type` is a bin or range
                       !is.na(.data$value),                          # Value not NA - the full matrix from data.csv file is still in data table
                       f_range_bin(.data$value, .data$ucn[1]),       # Convert value to appropriate units

--- a/R/process.R
+++ b/R/process.R
@@ -1195,8 +1195,7 @@ process_convert_units <- function(data, definitions, unit_conversion_functions) 
 
   # Split by unique unit conversions, to allow for as few calls as possible
   data <- data %>%
-    dplyr::group_by(.data$ucn, .data$to_convert) %>%
-    dplyr::rowwise() %>%
+    dplyr::group_by(.data$ucn, .data$to_convert, .data$value_type) %>%
     dplyr::mutate(
       # Standard conversion
       value = ifelse(

--- a/R/process.R
+++ b/R/process.R
@@ -1188,28 +1188,27 @@ process_convert_units <- function(data, definitions, unit_conversion_functions) 
   }
 
   f_range_bin <- function(value, name) {
-
-    stringr::str_split(value, "\\-\\-") %>%       # split into parts
-    purrr::map(f_standard, name) %>%                       # apply unit conversions to each
-    purrr::map_chr(~paste(.x, collapse = "--"))   # paste back together
+    stringr::str_split(value, "\\-\\-") %>%       # Split into parts
+    purrr::map(f_standard, name) %>%              # Apply unit conversions to each
+    purrr::map_chr(~paste(.x, collapse = "--"))   # Paste back together
   }
 
   # Split by unique unit conversions, to allow for as few calls as possible
   data <- data %>%
     dplyr::group_by(.data$ucn, .data$to_convert) %>%
     dplyr::mutate(
-      # standard conversion
-      value = ifelse(.data$to_convert == TRUE &                     # value requires conversion
-                      !.data$value_type %in% c("bin", "range") &    # value_type not a bin or range; those are converted below
-                      !is.na(.data$value),                          # value not NA - the full matrix from data.csv file is still in data table
-                      f_standard(.data$value, .data$ucn[1]),        # convert value to appropriate units
-                     .data$value),                                  # if conditions not met, keep original value
-      # value is a range of bin
-      value = ifelse(.data$to_convert == TRUE  &                    # value requires conversion
-                      .data$value_type %in% c("bin", "range") &     # value_type is a bin or range
-                      !is.na(.data$value),                          # value not NA - the full matrix from data.csv file is still in data table
-                      f_range_bin(.data$value, .data$ucn[1]),       # convert value to appropriate units
-                     .data$value),                                  # if conditions not met, keep original value
+      # Standard conversion
+      value = ifelse(.data$to_convert == TRUE &                     # Value requires conversion
+                      !.data$value_type %in% c("bin", "range") &    # `value_type` not a bin or range; those are converted below
+                      !is.na(.data$value),                          # Value not NA - the full matrix from data.csv file is still in data table
+                      f_standard(.data$value, .data$ucn[1]),        # Convert value to appropriate units
+                     .data$value),                                  # If conditions not met, keep original value
+      # Value is a range of bin
+      value = ifelse(.data$to_convert == TRUE  &                    # Value requires conversion
+                      .data$value_type %in% c("bin", "range") &     # `value_type` is a bin or range
+                      !is.na(.data$value),                          # Value not NA - the full matrix from data.csv file is still in data table
+                      f_range_bin(.data$value, .data$ucn[1]),       # Convert value to appropriate units
+                     .data$value),                                  # If conditions not met, keep original value
       unit = ifelse(.data$to_convert, .data$to, .data$unit_in)
     ) %>%
     dplyr::ungroup() %>%

--- a/R/process.R
+++ b/R/process.R
@@ -1199,17 +1199,19 @@ process_convert_units <- function(data, definitions, unit_conversion_functions) 
     dplyr::rowwise() %>%
     dplyr::mutate(
       # Standard conversion
-      value = ifelse(.data$to_convert == TRUE &                     # Value requires conversion
-                      !.data$value_type %in% c("bin", "range") &    # `value_type` not a bin or range; those are converted below
-                      !is.na(.data$value),                          # Value not NA - the full matrix from data.csv file is still in data table
-                      f_standard(.data$value, .data$ucn[1]),        # Convert value to appropriate units
-                     .data$value),                                  # If conditions not met, keep original value
+      value = ifelse(
+        .data$to_convert == TRUE &                    # Value requires conversion
+          !.data$value_type %in% c("bin", "range") &  # `value_type` not a bin or range; those are converted below
+          !is.na(.data$value),                        # Value not NA - the full matrix from data.csv file is still in data table
+          f_standard(.data$value, .data$ucn[1]),      # Convert value to appropriate units
+          .data$value),                               # If conditions not met, keep original value
       # Value is a range or bin
-      value = ifelse(.data$to_convert == TRUE &                    # Value requires conversion
-                      .data$value_type %in% c("bin", "range") &     # `value_type` is a bin or range
-                      !is.na(.data$value),                          # Value not NA - the full matrix from data.csv file is still in data table
-                      f_range_bin(.data$value, .data$ucn[1]),       # Convert value to appropriate units
-                     .data$value),                                  # If conditions not met, keep original value
+      value = ifelse(
+        .data$to_convert == TRUE &                    # Value requires conversion
+          .data$value_type %in% c("bin", "range") &   # `value_type` is a bin or range
+          !is.na(.data$value),                        # Value not NA - the full matrix from data.csv file is still in data table
+          f_range_bin(.data$value, .data$ucn[1]),     # Convert value to appropriate units
+          .data$value),                               # If conditions not met, keep original value
       unit = ifelse(.data$to_convert, .data$to, .data$unit_in)
     ) %>%
     dplyr::ungroup() %>%


### PR DESCRIPTION
The unit conversions warning (#65) was showing up again for both @ehwenk and me. It seems to me that there was something going on with the `mutate` `ifelse` statement not being vectorised in the expected way. I don't fully understand why it wasn't working as expected (because it should've been) but after several hours of testing I've just decided to accept that adding `rowwise` works and produces the expected output.

The problem dataset was once again, vanderMoezel_1987. 