### PR TITLE
Generalised database and target names

### DIFF
--- a/R/setup.R
+++ b/R/setup.R
@@ -1147,6 +1147,7 @@ metadata_find_taxonomic_change <- function(find, replace = NULL, studies = NULL)
 #'
 #' @param dataset_ids `dataset_id`'s to include; by default includes all
 #' @param method Approach to use in build
+#' @param database_name Name of database to be built
 #' @param template Template used to build
 #' @param workers Number of workers/parallel processes to use when using
 #' method = "furrr"
@@ -1155,6 +1156,7 @@ metadata_find_taxonomic_change <- function(find, replace = NULL, studies = NULL)
 #' @export
 build_setup_pipeline <- function(dataset_ids = dir("data"),
                                  method = "base",
+                                 database_name = "database",
                                  template = select_pipeline_template(method),
                                  workers = 1
                                  ) {
@@ -1185,6 +1187,7 @@ build_setup_pipeline <- function(dataset_ids = dir("data"),
     dataset_ids_vector =
       sprintf("c(%s)", sprintf("'%s'", dataset_ids) %>% paste(collapse = ", ")),
     path = path,
+    database_name = database_name,
     workers = workers
     )
 

--- a/inst/support/build_base.whisker
+++ b/inst/support/build_base.whisker
@@ -22,9 +22,9 @@ taxon_list <- read_csv_char("config/taxon_list.csv")
 
 {{database_name}}_raw <- build_combine(
 {{#dataset_ids}}
-        {{dataset_id}},
+  {{dataset_id}},
 {{/dataset_ids}}
-        NULL)
+  NULL)
 
 # Version information
 version_number <- util_get_version("config/metadata.yml")

--- a/inst/support/build_base.whisker
+++ b/inst/support/build_base.whisker
@@ -20,7 +20,7 @@ taxon_list <- read_csv_char("config/taxon_list.csv")
 
 {{/dataset_ids}}
 
-austraits_raw <- build_combine(
+{{database_name}}_raw <- build_combine(
 {{#dataset_ids}}
         {{dataset_id}},
 {{/dataset_ids}}
@@ -31,8 +31,8 @@ version_number <- util_get_version("config/metadata.yml")
 git_SHA <- util_get_SHA()
 
 # Combine all the source into one resource
-austraits <- build_add_version(austraits_raw, version_number, git_SHA)
+{{database_name}} <- build_add_version({{database_name}}_raw, version_number, git_SHA)
 
 # Save to file
 dir.create("export/data/curr", FALSE, TRUE)
-saveRDS(austraits, "export/data/curr/austraits.rds")
+saveRDS({{database_name}}, "export/data/curr/{{database_name}}.rds")

--- a/inst/support/build_furrr.whisker
+++ b/inst/support/build_furrr.whisker
@@ -35,15 +35,15 @@ plan(multisession, workers = {{workers}})
 
 sources <- future_map(dataset_ids, f, .progress = TRUE)
 
-austraits_raw <- build_combine(d = sources)
+{{database_name}}_raw <- build_combine(d = sources)
 
 # Version information
 version_number <- util_get_version("config/metadata.yml")
 git_SHA <- util_get_SHA()
 
 # Combine all the source into one resource
-austraits <- build_add_version(austraits_raw, version_number, git_SHA)
+{{database_name}} <- build_add_version({{database_name}}_raw, version_number, git_SHA)
 
 # Save to file
 dir.create("export/data/curr", FALSE, TRUE)
-saveRDS(austraits, "export/data/curr/austraits.rds")
+saveRDS({{database_name}}, "export/data/curr/{{database_name}}.rds")

--- a/inst/support/build_remake.whisker
+++ b/inst/support/build_remake.whisker
@@ -10,8 +10,8 @@ targets:
 # Define generic targets
   all:
     depends:
-      - austraits
-      - export/data/curr/austraits.rds
+      - {{database_name}}
+      - export/data/curr/{{database_name}}.rds
 
 # Load data resources
   schema:
@@ -52,7 +52,7 @@ targets:
 
 {{/dataset_ids}}
 
-  austraits_raw:
+  {{database_name}}_raw:
     command: >
       build_combine(
 {{#dataset_ids}}
@@ -70,9 +70,9 @@ targets:
       - .git/index
 
 # Combine all the source into one resource
-  austraits:
-    command: build_add_version(austraits_raw, version_number, git_SHA)
+  {{database_name}}:
+    command: build_add_version({{database_name}}_raw, version_number, git_SHA)
 
 # Save to file
-  export/data/curr/austraits.rds:
-    command: saveRDS(austraits, target_name)
+  export/data/curr/{{database_name}}.rds:
+    command: saveRDS({{database_name}}, target_name)

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -628,7 +628,7 @@ test_that("`build_setup_pipeline` is working", {
   expect_silent(suppressMessages(source("build.R", local = base_tmp_env)))
 
   targets <- c(
-    "austraits", "austraits_raw", "definitions", "git_SHA", "resource_metadata", "schema", "taxon_list",
+    "database", "database_raw", "definitions", "git_SHA", "resource_metadata", "schema", "taxon_list",
     "Test_2022", "Test_2022_config", "Test_2022_raw", "unit_conversions", "version_number"
   )
   expect_equal(sort(names(base_tmp_env)), sort(targets))
@@ -644,7 +644,7 @@ test_that("`build_setup_pipeline` is working", {
   expect_silent(suppressMessages(source("build.R", local = furrr_tmp_env)))
 
   targets <- c(
-    "austraits", "austraits_raw", "dataset_ids", "f", "definitions", "git_SHA", "resource_metadata",
+    "database", "database_raw", "dataset_ids", "f", "definitions", "git_SHA", "resource_metadata",
     "schema", "sources", "taxon_list", "unit_conversions", "version_number"
   )
   expect_equal(sort(names(furrr_tmp_env)), sort(targets))
@@ -656,8 +656,8 @@ test_that("`build_setup_pipeline` is working", {
   expect_true(file.exists("config/taxon_list.csv"))
 
   unlink(".remake", recursive = TRUE)
-  expect_silent(suppressMessages(austraits_raw <- remake::make("austraits_raw")))
-  expect_silent(suppressMessages(austraits <- remake::make("austraits")))
+  expect_silent(suppressMessages(austraits_raw <- remake::make("database_raw")))
+  expect_silent(suppressMessages(austraits <- remake::make("database")))
 
   # Test that austraits_raw has no version number or git_SHA
   expect_null(austraits_raw$build_info$version)
@@ -674,14 +674,30 @@ test_that("`build_setup_pipeline` is working", {
 
   # Compare products from three methods, except `build_info`
   v <- setdiff(names(austraits), "build_info")
-  expect_equal(base_tmp_env$austraits[v], austraits[v])
-  expect_equal(furrr_tmp_env$austraits[v], austraits[v])
+  expect_equal(base_tmp_env$database[v], austraits[v])
+  expect_equal(furrr_tmp_env$database[v], austraits[v])
 
+  # Try building database with a different name with base method
+  expect_silent(suppressMessages(build_setup_pipeline(method = "base", database_name = "test_name")))
+
+  base_tmp_env <- new.env()
+  expect_silent(suppressMessages(source("build.R", local = base_tmp_env)))
+
+  targets <- c(
+    "test_name", "test_name_raw", "definitions", "git_SHA", "resource_metadata", "schema", "taxon_list",
+    "Test_2022", "Test_2022_config", "Test_2022_raw", "unit_conversions", "version_number"
+  )
+  expect_equal(sort(names(base_tmp_env)), sort(targets))
+
+  # Try building database with a different name with `remake` method
+  expect_silent(suppressMessages(build_setup_pipeline(method = "remake", database_name = "test_name")))
+  expect_silent(suppressMessages(test_name_raw <- remake::make("test_name_raw")))
+  expect_silent(suppressMessages(test_name <- remake::make("test_name")))
 })
 
 
 testthat::test_that("`dataset_find_taxon` is working", {
-  expect_silent(suppressMessages(austraits <- remake::make("austraits")))
+  expect_silent(suppressMessages(austraits <- remake::make("test_name")))
   taxon <- c("Acacia celsa", "Acronychia acidula", "Aleurites rockinghamensis", "Syzygium sayeri")
   expect_no_error(x <- dataset_find_taxon(taxon, austraits), label = "`dataset_find_taxon`")
   expect_equal(unname(x[[4]]), "Test_2022")
@@ -690,7 +706,7 @@ testthat::test_that("`dataset_find_taxon` is working", {
 
 
 test_that("reports and plots are produced", {
-  expect_silent(suppressMessages(austraits <- remake::make("austraits")))
+  expect_silent(suppressMessages(austraits <- remake::make("test_name")))
   # Not testing right now
   #expect_no_error(
     #p <-


### PR DESCRIPTION
Closes #6
- Allows different databases to rename the database, instead of before using "austraits"
- Default is just set to "database", @ehwenk and I decided against "traits" because "traits$traits" is confusing