### PR TITLE
Excluded observations fix

### DIFF
--- a/R/process.R
+++ b/R/process.R
@@ -202,6 +202,22 @@ dataset_process <- function(filename_data_raw,
     dplyr::distinct() %>%
     dplyr::arrange(.data$aligned_name)
 
+  # Taxon names explicitly excluded in metadata also excluded from taxonomic updates table.
+  if (!is.na(metadata[["exclude_observations"]][1])) {
+    taxa_to_exclude <- 
+        metadata[["exclude_observations"]] %>%
+        traits.build::util_list_to_df2() %>%
+        dplyr::mutate(
+          find = stringr::str_split(find, ", ")
+          ) %>%
+        tidyr::unnest_longer(find) %>%
+        dplyr::filter(variable == "taxon_name")
+
+    taxonomic_updates <- 
+      taxonomic_updates %>%
+      dplyr::filter(!aligned_name %in% taxa_to_exclude$find)
+  }
+
   ## A temporary dataframe created to generate and bind `method_id`,
   ## for instances where the same trait is measured twice using different methods
 

--- a/tests/testthat/examples/Test_2023_1/output/taxonomic_updates.csv
+++ b/tests/testthat/examples/Test_2023_1/output/taxonomic_updates.csv
@@ -41,6 +41,5 @@ Test_2023_1,Psychotria sp Utchee Creek,Psychotria sp. Utchee Creek (H.Flecker NQ
 Test_2023_1,Quassia baileyana,Quassia baileyana,,
 Test_2023_1,Rhodomyrtus trineura,Rhodomyrtus trineura,,
 Test_2023_1,Rockinghamia angustifolia,Rockinghamia angustifolia,,
-Test_2023_1,Syzygium gustavioides,Syzygium gustavioides,,
 Test_2023_1,Syzygium sayeri,Syzygium sayeri,,
 Test_2023_1,Trema aspera,Trema aspera,,


### PR DESCRIPTION
Taxon names explicitly excluded under `exclude observations` are now also excluded from the taxonomic updates table