### PR TITLE
Taxonomic updates fixes

### DIFF
--- a/R/process.R
+++ b/R/process.R
@@ -262,7 +262,8 @@ dataset_process <- function(filename_data_raw,
     dplyr::filter(!is.na(.data$error)) %>%
     dplyr::select(dplyr::all_of(c("error")), everything()) %>%
     dplyr::select(-dplyr::all_of(c("unit_in"))),
-    taxonomic_updates = taxonomic_updates,
+    taxonomic_updates = taxonomic_updates %>%
+      dplyr::filter(aligned_name %in% traits$taxon_name),
     taxa = taxonomic_updates %>%
       dplyr::select(dplyr::all_of(c(taxon_name = "aligned_name"))) %>%
       dplyr::distinct(),

--- a/R/process.R
+++ b/R/process.R
@@ -1811,11 +1811,11 @@ build_combine <- function(..., d = list(...)) {
   # Taxonomy
   taxonomic_updates <-
     combine("taxonomic_updates", d) %>%
-    dplyr::group_by(.data$original_name, .data$taxon_name, .data$taxonomic_resolution) %>%
+    dplyr::group_by(.data$original_name, .data$aligned_name, .data$taxon_name, .data$taxonomic_resolution) %>%
     dplyr::mutate(dataset_id = paste(.data$dataset_id, collapse = " ")) %>%
     dplyr::ungroup() %>%
     dplyr::distinct() %>%
-    dplyr::arrange(.data$original_name, .data$taxon_name, .data$taxonomic_resolution)
+    dplyr::arrange(.data$original_name, .data$aligned_name, .data$taxon_name, .data$taxonomic_resolution)
 
   # Metadata
   contributors <- combine("contributors", d)


### PR DESCRIPTION
Two fixes:

- Added `align_name` to group_by argument to ensure `dataset_id` correctly attributed to `original_name` by `aligned_name` combinations. (Fixes issue #117)

- Filter taxonomic_updates to only include taxa for which trait data exists,

NOTE: the taxa table still includes taxa in excluded data - I think this is OK, but noting...