### PR TITLE
Error if no contexts

### DIFF
--- a/R/testdata.R
+++ b/R/testdata.R
@@ -591,8 +591,14 @@ dataset_test_worker <-
         )
 
         # Check that there are no duplicate `var_in` or `context_property` fields
-        context_properties <- sapply(metadata[["contexts"]], "[[", "context_property")
-        context_vars_in <- sapply(metadata[["contexts"]], "[[", "var_in")
+
+        if(is.na(metadata[["contexts"]])) {
+          context_properties <- metadata[["contexts"]]
+          context_vars_in <- metadata[["contexts"]]
+        } else {
+          context_properties <- sapply(metadata[["contexts"]], "[[", "context_property")
+          context_vars_in <- sapply(metadata[["contexts"]], "[[", "var_in")
+        }
 
         expect_equal(
           context_properties |> duplicated() |> sum(),

--- a/R/testdata.R
+++ b/R/testdata.R
@@ -737,12 +737,15 @@ dataset_test_worker <-
         )
 
         # Check units are found in `unit_conversions.csv`
-        units <- read_csv("config/unit_conversions.csv")
-        expect_is_in(
-          traits$unit_in, units$unit_from,
-          info = paste0(red(f), "\ttraits"),
-          label = "`unit_in`'s"
-        )
+        # This test is being commented out, because fails anytime columns are read in 
+        # or anytime there are units not in unit_conversions because they are never converted.
+        
+        #units <- read_csv("config/unit_conversions.csv")
+        #expect_is_in(
+        #  traits$unit_in, units$unit_from,
+        #  info = paste0(red(f), "\ttraits"),
+        #  label = "`unit_in`'s"
+        #)
 
         # Check no duplicate `var_in`'s
 


### PR DESCRIPTION
Fixing two small tests errors:
- error is no contexts 
- test for unit_in in unit_conversions.csv isn't correct - we don't expect this behaviour always.

Should merge in, because I'd already forgotten I'd fixed the contexts error once and just did it a second time...