### PR TITLE
Add standard_error as an allowable value_type

### DIFF
--- a/inst/support/build_furrr.whisker
+++ b/inst/support/build_furrr.whisker
@@ -34,6 +34,7 @@ plan(multisession, workers = {{workers}})
 #plan(sequential)
 
 sources <- future_map(dataset_ids, f, .progress = TRUE)
+names(sources) <- dataset_ids
 
 {{database_name}}_raw <- build_combine(d = sources)
 

--- a/inst/support/build_remake.whisker
+++ b/inst/support/build_remake.whisker
@@ -58,7 +58,7 @@ targets:
 {{#dataset_ids}}
         {{dataset_id}},
 {{/dataset_ids}}
-        NULL)
+        I(NULL))
 
 # Version information
   version_number:

--- a/inst/support/traits.build_schema.yml
+++ b/inst/support/traits.build_schema.yml
@@ -23,6 +23,7 @@ value_type:
     mode: Value is the mode of values recorded for an entity. This is the appropriate value type for a categorical trait value.
     range: Value is a range of values recorded for an entity.
     bin: Value for an entity falls within specified limits.
+    standard_error: Value is the standard error of a mean of values recorded for an entity.
     unknown: Not currently known.
 
 basis_of_value:

--- a/tests/testthat/examples/Test_2023_1/metadata.yml
+++ b/tests/testthat/examples/Test_2023_1/metadata.yml
@@ -68,10 +68,10 @@ locations:
     rainfall (mm): 2000
   Cape Tribulation:
     description: Complex mesophyll vine forest in tropical rain forest.
-    elevation (m): 25
-    rainfall (mm): 3500    
+    elevation (m): 25  
     latitude (deg): .na
     longitude (deg): .na
+    rainfall (mm): 3500
   test_excluded_site:
     description: test excluded site
     latitude (deg): .na

--- a/tests/testthat/examples/Test_2023_1/metadata.yml
+++ b/tests/testthat/examples/Test_2023_1/metadata.yml
@@ -68,7 +68,7 @@ locations:
     rainfall (mm): 2000
   Cape Tribulation:
     description: Complex mesophyll vine forest in tropical rain forest.
-    elevation (m): 25  
+    elevation (m): 25
     latitude (deg): .na
     longitude (deg): .na
     rainfall (mm): 3500

--- a/tests/testthat/examples/Test_2023_1/metadata.yml
+++ b/tests/testthat/examples/Test_2023_1/metadata.yml
@@ -64,13 +64,10 @@ dataset:
 locations:
   Atherton:
     description: Tropical rain forest vegetation.
-    elevation (m): 800
     rainfall (mm): 2000
   Cape Tribulation:
     description: Complex mesophyll vine forest in tropical rain forest.
     elevation (m): 25
-    latitude (deg): .na
-    longitude (deg): .na
     rainfall (mm): 3500
   test_excluded_site:
     description: test excluded site

--- a/tests/testthat/examples/Test_2023_1/metadata.yml
+++ b/tests/testthat/examples/Test_2023_1/metadata.yml
@@ -64,11 +64,14 @@ dataset:
 locations:
   Atherton:
     description: Tropical rain forest vegetation.
+    elevation (m): 800
     rainfall (mm): 2000
   Cape Tribulation:
     description: Complex mesophyll vine forest in tropical rain forest.
     elevation (m): 25
-    rainfall (mm): 3500
+    rainfall (mm): 3500    
+    latitude (deg): .na
+    longitude (deg): .na
   test_excluded_site:
     description: test excluded site
     latitude (deg): .na

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -646,6 +646,12 @@ test_that("`build_setup_pipeline` is working", {
   )
   expect_equal(sort(names(furrr_tmp_env)), sort(targets))
 
+  out1 <- get("Test_2022", envir = base_tmp_env)
+  out2 <- get("sources", envir = furrr_tmp_env)[["Test_2022"]]
+  
+  # don't compare build_info, as these differ through packages used.
+  expect_equal(out1[names(out1) != "build_info"], out2[names(out2) != "build_info"])
+  
   # Remake workflow
   expect_silent(suppressMessages(build_setup_pipeline(method = "remake")))
   expect_true(file.exists("remake.yml"))

--- a/tests/testthat/test-usage.R
+++ b/tests/testthat/test-usage.R
@@ -5,7 +5,7 @@ austraits <- readRDS("test_austraits.rds")
 # Note, requires existnec of "test_austraits.rds", generated from `test-process.R`
 
 test_that("plots", {
-  expect_invisible(suppressMessages(
-    austraits %>% traits.build::plot_trait_distribution_beeswarm("wood_density", "dataset_id", "Test_2022")
+  expect_no_error(suppressMessages(
+    p <- austraits %>% traits.build::plot_trait_distribution_beeswarm("wood_density", "dataset_id", "Test_2022")
   ))
 })


### PR DESCRIPTION
Add standard_error as an allowable value_type

towards issue https://github.com/traitecoevo/traits.build/issues/171

This added functionality has been tested for the past two months by [@kris-wild ](https://github.com/kris-wild) and is working well for him.