### PR TITLE
edit pkgdown.yml, add "<"

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -144,3 +144,10 @@ reference:
     - '`notetaker_print_notes`'
     - '`notes_random_string`'
 
+  - title: Deprecated function names
+    desc: Functions that have been moved from traits.build to austraits and renamed. Deprecated names still work.
+    contents:
+    - '`build_combine`'
+    - '`util_df_to_list`'
+    - '`util_list_to_df1`'
+    - '`util_list_to_df2`'

--- a/ontology/data/traits.build_resource.csv
+++ b/ontology/data/traits.build_resource.csv
@@ -11,4 +11,4 @@ Subject,Predicate,Object
 <https://w3id.org/traits.build>,<http://purl.org/dc/terms/creator>,"""Elizabeth Wenk"""
 <https://w3id.org/traits.build>,<http://purl.org/dc/terms/creator>,"""Sophie Yang"""
 <https://w3id.org/traits.build>,<http://purl.org/dc/terms/created>,"""01 February 2024^^<xsd:date>"""
-https://w3id.org/traits.build#traits.build-database,<http://www.w3.org/2004/02/skos/core#topConceptOf>,"""<https://w3id.org/traits.build>""^^<xsd:anyURI>"
+<https://w3id.org/traits.build#traits.build-database>,<http://www.w3.org/2004/02/skos/core#topConceptOf>,"""<https://w3id.org/traits.build>""^^<xsd:anyURI>"


### PR DESCRIPTION
Two fixes:
- needed to add deprecated/renamed functions to pkgdown.yml since they are still valid function names output by traits.build
- missed a pair of brackets in ontology