### PR TITLE
Fix 3 small bugs

### DIFF
--- a/R/setup.R
+++ b/R/setup.R
@@ -390,7 +390,7 @@ metadata_add_locations <- function(dataset_id, location_data, user_responses = N
   }
 
   metadata$locations <- location_data %>%
-    dplyr::select(-dplyr::any_of("location_name")) %>%
+    dplyr::select(-dplyr::any_of(location_name)) %>%
     split(location_data[[location_name]]) %>%
     lapply(as.list)
 

--- a/inst/support/report_dataset.Rmd
+++ b/inst/support/report_dataset.Rmd
@@ -99,7 +99,7 @@ library(kableExtra)
 my_kable_styling <- util_kable_styling_html
 
 definitions <- austraits$definitions
-data_study <- extract_dataset(austraits, dataset_id)
+data_study <- extract_dataset(austraits, dataset_id, partial_matches_allowed = F)
 metadata <- read_metadata(file.path("data", dataset_id, "metadata.yml"))
 schema <- austraits$schema
 
@@ -565,7 +565,9 @@ if (nrow(filter(data_study$excluded_data, error == "Value out of allowable range
     writeLines()
 }
 
-  austraits::plot_trait_distribution_beeswarm(austraits, trait, "dataset_id", highlight = dataset_id, hide_ids = TRUE)
+  austraits_no_bins <- extract_data(austraits, table = "traits", col = "value_type", col_value = c("mean", "median", "minimum", "maximum", "raw"))
+  
+  austraits::plot_trait_distribution_beeswarm(austraits_no_bins, trait, "dataset_id", highlight = dataset_id, hide_ids = TRUE)
 
   writeLines(c(""))
 

--- a/traits.build.Rproj
+++ b/traits.build.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 063a2e9e-460a-4c1c-b6cf-950ccaf5a3ea
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
- metadata_add_locations:
1. remove quotes around "location_name"; this was only removing the "location_name" variable when it was actually "location_name" and otherwise automatically adding it as another location_property

- dataset_report:
1. need to add "raw" values to value types that are plotted
2. ensure partial_matches_allowed set to "F" so if there are multiple author_year dataset_id's only the intended one is extracted