### PR TITLE
Update testdata.R

### DIFF
--- a/R/testdata.R
+++ b/R/testdata.R
@@ -650,7 +650,7 @@ dataset_test_worker <-
             )
 
             # If trait is categorical
-            if (!is.null(definitions$elements[[trait]]) && definitions$elements[[trait]]$type == "categorical") {
+            if (!is.null(definitions$elements[[trait]]$allowed_values_levels) && definitions$elements[[trait]]$type == "categorical") {
 
               # Check replacement values
               to_check <- x[[trait]]$replace %>% unique()


### PR DESCRIPTION
Coincidentally I just found a tiny bug in a substitutions test that I don't think has ever been triggered before - testing for substitutions and having one of the "_time" traits tested - we usually always add flowering/fruiting etc time via functions, but I manually added some "foliage time" NY sequences.

Would like to merge this in before release!