### PR TITLE
docs: add cross-package pointer to austraits-meta

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,25 @@
+# traits.build — agent guide
+
+> ⚠️ **Package-local guidance is TODO.** This stub currently only points to family-wide
+> context. Add traits.build-specific architecture, build/test commands, and gotchas below.
+
+## Cross-package context
+
+`traits.build` is part of the **AusTraits family**. Cross-package concerns are documented
+centrally in the **[austraits-meta](https://github.com/traitecoevo/austraits-meta)** repo —
+don't restate them here, read them there:
+
+- **Start with [`AGENTS.md`](https://github.com/traitecoevo/austraits-meta/blob/main/AGENTS.md)** —
+  pipeline order, who owns what, dependency direction (incl. the reversed
+  `traits.build` → `austraits` edge), source-of-truth rules, cross-boundary artifacts, gotchas.
+- **[`dependencies.yml`](https://github.com/traitecoevo/austraits-meta/blob/main/dependencies.yml)** —
+  machine-readable package graph + artifacts.
+- **[`governance/`](https://github.com/traitecoevo/austraits-meta/tree/main/governance)** —
+  label taxonomy, board #9 conventions, release playbooks, triage.
+
+> austraits-meta is hand-maintained prose — a map, not ground truth. Verify specifics against
+> the actual repos.
+
+## Package-local guidance (TODO)
+
+_To be written: traits.build-specific architecture, key entry points, build & test, known gotchas._

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,25 +1,9 @@
-# traits.build — agent guide
+# CLAUDE.md
 
-> ⚠️ **Package-local guidance is TODO.** This stub currently only points to family-wide
-> context. Add traits.build-specific architecture, build/test commands, and gotchas below.
+This repo keeps its agent & contributor guidance in **[`AGENTS.md`](../AGENTS.md)** so the same
+content is tool-agnostic and shared across every agent.
 
-## Cross-package context
+**👉 Read [`AGENTS.md`](../AGENTS.md)** for repo-local orientation (architecture, build & test,
+gotchas) and the AusTraits-family cross-package pointer.
 
-`traits.build` is part of the **AusTraits family**. Cross-package concerns are documented
-centrally in the **[austraits-meta](https://github.com/traitecoevo/austraits-meta)** repo —
-don't restate them here, read them there:
-
-- **Start with [`AGENTS.md`](https://github.com/traitecoevo/austraits-meta/blob/main/AGENTS.md)** —
-  pipeline order, who owns what, dependency direction (incl. the reversed
-  `traits.build` → `austraits` edge), source-of-truth rules, cross-boundary artifacts, gotchas.
-- **[`dependencies.yml`](https://github.com/traitecoevo/austraits-meta/blob/main/dependencies.yml)** —
-  machine-readable package graph + artifacts.
-- **[`governance/`](https://github.com/traitecoevo/austraits-meta/tree/main/governance)** —
-  label taxonomy, board #9 conventions, release playbooks, triage.
-
-> austraits-meta is hand-maintained prose — a map, not ground truth. Verify specifics against
-> the actual repos.
-
-## Package-local guidance (TODO)
-
-_To be written: traits.build-specific architecture, key entry points, build & test, known gotchas._
+Don't duplicate that content here — edit `AGENTS.md` and this file stays correct by reference.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# traits.build — agent & contributor guide
+
+`traits.build` is an R package providing a **workflow to harmonise trait data** from diverse
+sources into a documented, relational standard structure. It is the generic engine spun out of the
+AusTraits project in 2023 (see Wenk et al. 2024, doi:10.1016/j.ecoinf.2024.102773).
+
+## Repo-local guidance
+
+- **Code:** `R/` (functions), `tests/` (testthat), `man/` (generated docs), `NAMESPACE`.
+- **Data-model ontology:** `ontology/` documents the ontology of the *data model*
+  (entities/relations). This is **not** APD's trait-definition vocabulary — they're parallel, don't
+  conflate them (see family context below).
+- **Schema:** the relational `traits.build` schema is the source of truth for the data structure
+  that other family repos conform to.
+- **Docs:** user manual at the [traits.build-book](https://traitecoevo.github.io/traits.build-book/);
+  function reference at <http://traitecoevo.github.io/traits.build/>.
+
+Dev follows the standard R-package workflow: `devtools::load_all()`, `devtools::test()`,
+`devtools::check()`. Default development branch is `develop`. Note the README's **deprecated**
+lifecycle badge — confirm intent before large new features.
+
+> Heads-up: `traits.build` **Imports `austraits`** (it re-exports a few conversion helpers), so the
+> R-package install graph runs `traits.build → austraits` even though in the *data* pipeline
+> traits.build is upstream of austraits. Run traits.build's tests after touching those helpers.
+
+---
+
+## AusTraits family — cross-package context
+
+`traits.build` is part of the **AusTraits family** (a subset of the
+[`traitecoevo`](https://github.com/traitecoevo) org) — here, the generic workflow engine + relational
+data model/schema. Family-wide concerns are documented centrally in
+**[austraits-meta](https://github.com/traitecoevo/austraits-meta)** — don't restate them here, read
+them there:
+
+- **Start with [`AGENTS.md`](https://github.com/traitecoevo/austraits-meta/blob/main/AGENTS.md)** —
+  pipeline order, who owns what, dependency direction (incl. the reversed `traits.build → austraits`
+  edge), source-of-truth rules, cross-boundary artifacts, gotchas.
+- **[`dependencies.yml`](https://github.com/traitecoevo/austraits-meta/blob/main/dependencies.yml)** —
+  machine-readable package graph + cross-boundary artifacts.
+- **[`governance/`](https://github.com/traitecoevo/austraits-meta/tree/main/governance)** —
+  label taxonomy, board #9 conventions, release playbooks, triage.
+
+**Filing issues:** the whole family is tracked on one board,
+[AusTraits #9](https://github.com/orgs/traitecoevo/projects/9) (new issues auto-add to it). Follow
+the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta/blob/main/governance/issue-guide.md):
+pick one work-type label (`bug` / `task` / `epic`); Status and Priority are set on the board, not as
+labels.
+
+> austraits-meta is hand-maintained prose — a map, not ground truth. Verify specifics against the
+> actual repos.

--- a/README.md
+++ b/README.md
@@ -88,3 +88,15 @@ DOI: [10.1038/s41597-021-01006-6](http://doi.org/10.1038/s41597-021-01006-6)
 
 **Funding**: The AusTraits project received investment (<https://doi.org/10.47486/TD044>, <https://doi.org/10.47486/DP720>) from the Australian Research Data Commons (ARDC). The ARDC is funded by the National Collaborative Research Infrastructure Strategy (NCRIS).
 
+
+## AusTraits family
+
+`traits.build` is part of the **AusTraits family** of packages maintained by the
+[AusTraits](https://austraits.org) team. See **[austraits.org](https://austraits.org)** for the
+project, the data, and the people behind it.
+
+Contributing? Issues across the family are tracked on one board,
+[AusTraits #9](https://github.com/orgs/traitecoevo/projects/9), and new issues are auto-added. Please
+read the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta/blob/main/governance/issue-guide.md)
+in [`austraits-meta`](https://github.com/traitecoevo/austraits-meta) — the family's cross-package
+knowledge and governance hub — before filing.


### PR DESCRIPTION
Adds the **AusTraits family** cross-package pointer to this repo, following the
[`austraits-meta`](https://github.com/traitecoevo/austraits-meta) convention.

**Structure (CLAUDE.md is a stub; AGENTS.md holds the content):**
- `.claude/CLAUDE.md` — short stub that defers to `AGENTS.md`.
- `AGENTS.md` — repo-local guidance (architecture, build & test, gotchas) **plus** an *AusTraits
  family* section pointing to austraits-meta (`AGENTS.md`, `dependencies.yml`, `governance/`) and the
  issue/board #9 guide.
- `README.md` — an *AusTraits family* section (→ [austraits.org](https://austraits.org) for the
  project/team; → austraits-meta `governance/issue-guide.md` + board #9 for contributing).

Package-local guidance is seeded from `DESCRIPTION`/`README`; cross-package concerns are linked, not
restated. Part of bootstrapping `austraits-meta`. Opened as **draft** for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)