### PR TITLE
Fix R-devel R CMD check failures (identifiers schema, citation dash, non-ASCII)

### DIFF
--- a/R/process.R
+++ b/R/process.R
@@ -1074,6 +1074,9 @@ bib_print <- function(bib, .opts = list(first.inits = TRUE, max.names = 1000, st
     gsub("  ", " ", .) %>%
     gsub("DOI:", " doi: ", ., fixed = TRUE) %>%
     gsub("URL:", " url: ", ., fixed = TRUE) %>%
+    # Normalise page-range dashes to a plain hyphen so output is stable across
+    # RefManageR versions (newer versions render page ranges with an en-dash)
+    gsub("(pp?\\. \\d+)[\u2013\u2014](\\d+)", "\\1-\\2", .) %>%
     ifelse(tolower(bib$bibtype) == "article",  gsub("In:", " ", .), .)
 }
 
@@ -1674,7 +1677,7 @@ process_format_contributors <- function(my_list, dataset_id, schema) {
 #' \dontrun{
 #' process_format_identifiers(read_metadata("data/Falster_2003/metadata.yml")$identifiers)
 #' }
-process_format_identifiers <- function(my_list, dataset_id, traits) {
+process_format_identifiers <- function(my_list, dataset_id, schema) {
 
     if (length(unlist(my_list$identifiers)) > 1) {
       identifiers <-

--- a/R/setup.R
+++ b/R/setup.R
@@ -567,8 +567,6 @@ metadata_add_contexts <- function(dataset_id, overwrite = FALSE, user_responses 
 #'
 #' @inheritParams metadata_path_dataset_id
 #' @param overwrite Overwrite existing information
-#' @param user_responses Named list containing simulated user input for manual selection
-#' of variables, mainly for testing purposes
 #'
 #' @importFrom rlang .data
 #' @export

--- a/R/test_functions.R
+++ b/R/test_functions.R
@@ -212,7 +212,7 @@ colour_characters <- function(x, i = NULL) {
 }
 
 
-check_disallowed_chars <- function(x, exceptions = c("ÁÅÀÂÄÆÃĀâíåæäãàáíÇčóöøéèłńl°êÜüùúû±µµ“”‘’-–—≈˜×≥≤")) {
+check_disallowed_chars <- function(x, exceptions = c("\u00c1\u00c5\u00c0\u00c2\u00c4\u00c6\u00c3\u0100\u00e2\u00ed\u00e5\u00e6\u00e4\u00e3\u00e0\u00e1\u00ed\u00c7\u010d\u00f3\u00f6\u00f8\u00e9\u00e8\u0142\u0144l\u00b0\u00ea\u00dc\u00fc\u00f9\u00fa\u00fb\u00b1\u00b5\u00b5\u201c\u201d\u2018\u2019-\u2013\u2014\u2248\u02dc\u00d7\u2265\u2264")) {
 
   i <- charToRaw(x)
   # Allow all ascii text

--- a/R/testdata.R
+++ b/R/testdata.R
@@ -228,7 +228,7 @@ dataset_test_worker <-
             testthat::expect_silent(
               identifiers <-
                 metadata$identifiers %>%
-                process_format_identifiers(dataset_id, data)
+                process_format_identifiers(dataset_id, schema)
             )
           }
         }

--- a/man/metadata_add_identifiers.Rd
+++ b/man/metadata_add_identifiers.Rd
@@ -10,9 +10,6 @@ metadata_add_identifiers(dataset_id, overwrite = FALSE)
 \item{dataset_id}{Identifier for a particular study in the database}
 
 \item{overwrite}{Overwrite existing information}
-
-\item{user_responses}{Named list containing simulated user input for manual selection
-of variables, mainly for testing purposes}
 }
 \description{
 This functions asks users which columns in the dataframe they would like to keep

--- a/man/process_format_identifiers.Rd
+++ b/man/process_format_identifiers.Rd
@@ -4,7 +4,7 @@
 \alias{process_format_identifiers}
 \title{Format identifiers from list into tibble}
 \usage{
-process_format_identifiers(my_list, dataset_id, traits)
+process_format_identifiers(my_list, dataset_id, schema)
 }
 \arguments{
 \item{my_list}{List of input information}


### PR DESCRIPTION
## Summary

Fixes the failing r-universe R CMD check on R-devel ([example run](https://github.com/r-universe/traitecoevo/actions/runs/28910422440)). Three independent problems, all verified fixed locally (`921 tests, 0 failures, 0 warnings`).

### 1. ERROR — `object 'schema' not found`
`process_format_identifiers()` took a third argument named `traits` but its body (and roxygen `@param`) used `schema`. It errored for any dataset with an `identifiers:` block (e.g. `Test_2023_2`). It was previously masked by `schema` leaking from the global environment during tests; R-devel no longer leaks it. Fixed the signature to `schema` and updated the call site in `dataset_test_worker()`.

### 2. FAILURE — citation en-dash vs hyphen
`source_primary_citation` differed by one character (`pp. 521–535` vs `521-535`). Newer RefManageR renders page ranges with an en-dash; the fixtures use a hyphen. Added a targeted `gsub` in `bib_print()` that normalizes en/em-dashes **within page ranges** to a plain hyphen, so output is deterministic across RefManageR versions (release ships 1.4.0, which emits hyphens). Dashes in titles are untouched.

### 3. WARNING — non-ASCII in R code
`R/test_functions.R` hard-coded accented/dash characters in `check_disallowed_chars`. Replaced with `\uXXXX` escapes (same characters, ASCII-only source).

### Bonus — `Rd \usage` warnings
Both stemmed from the same doc/signature drift. Regenerated the two affected `.Rd` files and removed a stray `@param user_responses` from `metadata_add_identifiers()` (the function has no such argument).

## Note
`source_primary_citation` now consistently uses a hyphen — consistent with existing expected outputs and release builds, so no stored data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)