### PR TITLE
Stop dataset_test aborting on multiple identifiers (#218)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,6 +56,7 @@ Suggests:
     ggbeeswarm,
     gridExtra,
     scales,
+    withr,
     zip,
     covr
 Remotes:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# traits.build (development version)
+
+- `dataset_test()` no longer aborts with `the condition has length > 1` for a dataset that declares more than one identifier. `metadata$identifiers` is a list, so `is.na()` on it returns one value per identifier.
+
 # traits.build 2.1.0
 
 - Identifiers table added, allowing trait values to be linked to a specific identifiers in an herbarium, museum collection, GenBank, or an arboretum. If a data contributor has collected data on the same individual plants across multiple datasets, these can also be linked.

--- a/R/testdata.R
+++ b/R/testdata.R
@@ -223,25 +223,21 @@ dataset_test_worker <-
         )
 
         ## Identifiers
-        if (!is.null(metadata$identifiers)) {
-          if (!is.na(metadata$identifiers)) {
-            testthat::expect_silent(
-              identifiers <-
-                metadata$identifiers %>%
-                process_format_identifiers(dataset_id, data)
-            )
-          }
-        }
-        
-        
-        if (!is.null(metadata$identifiers)) {
-          if (!is.na(metadata$identifiers)) {
+        # A dataset may declare several identifiers, so `metadata$identifiers`
+        # is a list and `is.na()` on it returns one value per element
+        if ("identifiers" %in% names(metadata) & !all(is.na(metadata[["identifiers"]]))) {
+
+          testthat::expect_silent(
+            identifiers <-
+              metadata$identifiers %>%
+              process_format_identifiers(dataset_id, data)
+          )
+
           test_expect_list_elements_exact_names(
             metadata$identifiers,
             schema$metadata$elements$identifiers$elements %>% names(),
             info = paste0(red(f), "\tidentifiers")
           )
-          }
         }
         
         ## Locations

--- a/tests/testthat/test-dataset-test.R
+++ b/tests/testthat/test-dataset-test.R
@@ -1,0 +1,15 @@
+test_that("`dataset_test` handles datasets declaring more than one identifier", {
+  # A dataset may declare several identifiers, so `metadata$identifiers` is a
+  # list and `is.na()` on it returns one value per element. Guarding with
+  # `if (!is.na(metadata$identifiers))` therefore aborted the whole run with
+  # "the condition has length > 1" for any such dataset.
+  expect_gt(length(read_metadata("examples/Test_2023_1/metadata.yml")$identifiers), 1)
+
+  out <- capture.output(
+    suppressMessages(
+      dataset_test(dataset_ids = "Test_2023_1", path_data = "examples")
+    )
+  )
+
+  expect_false(any(grepl("the condition has length > 1", out, fixed = TRUE)))
+})

--- a/tests/testthat/test-dataset-test.R
+++ b/tests/testthat/test-dataset-test.R
@@ -1,9 +1,19 @@
-test_that("`dataset_test` handles datasets declaring more than one identifier", {
+test_that("`dataset_test` handles several identifiers", {
   # A dataset may declare several identifiers, so `metadata$identifiers` is a
   # list and `is.na()` on it returns one value per element. Guarding with
   # `if (!is.na(metadata$identifiers))` therefore aborted the whole run with
   # "the condition has length > 1" for any such dataset.
-  expect_gt(length(read_metadata("examples/Test_2023_1/metadata.yml")$identifiers), 1)
+  metadata <- read_metadata("examples/Test_2023_1/metadata.yml")
+  expect_gt(length(metadata$identifiers), 1)
+
+  # `dataset_test` reads `config/taxon_list.csv`, which is not in the repository
+  # — it is created as a side effect of `test-setup.R`. Test files run
+  # alphabetically, so this one runs first on a clean checkout. Seed it from the
+  # committed fixture that `test-setup.R` copies over it anyway.
+  if (!file.exists("config/taxon_list.csv")) {
+    file.copy("config/taxon_list-orig.csv", "config/taxon_list.csv")
+    withr::defer(unlink("config/taxon_list.csv"))
+  }
 
   out <- capture.output(
     suppressMessages(


### PR DESCRIPTION
Closes #218.

`dataset_test()` aborts entirely — not just fails a check — for any dataset declaring more than one identifier. `Test_2023_1` is such a dataset, which is why `tests/testthat/test-xamples.R` currently fails on `develop`.

## Cause

`metadata$identifiers` holds a *list* of identifiers, so `is.na()` on it returns one value per identifier. Guarding with

```r
if (!is.na(metadata$identifiers))
```

therefore raises `the condition has length > 1` under R >= 4.2, stopping the whole run:

```
── Error: Test_2023_1 ──
Error in `if (!is.na(metadata$identifiers)) { ... }`: the condition has length > 1
```

## Fix

Use the guard already applied to this same field further down the file:

```r
if ("identifiers" %in% names(metadata) & !all(is.na(metadata[["identifiers"]])))
```

and collapse the two redundant nested conditionals into one block.

## Needs the signature fix too

With this alone, `dataset_test()` no longer aborts but still reports `object 'schema' not found` for every dataset with identifiers, because `process_format_identifiers()` refers to `schema` in its body while its parameter is named `traits` and the caller passes `data`. That is fixed on `fix/rdevel-check-identifiers-citation`.

With **both** applied I confirmed `dataset_test("Test_2023_1")` runs to completion and reports only the intentional failure:

```
examples/Test_2023_1/metadata.yml	traits - `trait_name`'s should not contain: 'wrong_trait_name'
```

so `test-xamples.R` should go green once both land. I have kept them separate rather than duplicating your commit — happy to rebase onto that branch instead if you would prefer them to go in together.

## Tests

New `tests/testthat/test-dataset-test.R` asserts `Test_2023_1` really does declare more than one identifier (so the test cannot silently stop covering the case) and that the run does not emit `the condition has length > 1`. Verified it fails before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)