### PR TITLE
Forward-port #214 and #215 from master to develop

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,9 @@
+# CLAUDE.md
+
+This repo keeps its agent & contributor guidance in **[`AGENTS.md`](../AGENTS.md)** so the same
+content is tool-agnostic and shared across every agent.
+
+**👉 Read [`AGENTS.md`](../AGENTS.md)** for repo-local orientation (architecture, build & test,
+gotchas) and the AusTraits-family cross-package pointer.
+
+Don't duplicate that content here — edit `AGENTS.md` and this file stays correct by reference.

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,12 @@
+name: Add new issues to AusTraits board #9
+on:
+  issues:
+    types: [opened]
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/traitecoevo/projects/9
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# traits.build — agent & contributor guide
+
+`traits.build` is an R package providing a **workflow to harmonise trait data** from diverse
+sources into a documented, relational standard structure. It is the generic engine spun out of the
+AusTraits project in 2023 (see Wenk et al. 2024, doi:10.1016/j.ecoinf.2024.102773).
+
+## Repo-local guidance
+
+- **Code:** `R/` (functions), `tests/` (testthat), `man/` (generated docs), `NAMESPACE`.
+- **Data-model ontology:** `ontology/` documents the ontology of the *data model*
+  (entities/relations). This is **not** APD's trait-definition vocabulary — they're parallel, don't
+  conflate them (see family context below).
+- **Schema:** the relational `traits.build` schema is the source of truth for the data structure
+  that other family repos conform to.
+- **Docs:** user manual at the [traits.build-book](https://traitecoevo.github.io/traits.build-book/);
+  function reference at <http://traitecoevo.github.io/traits.build/>.
+
+Dev follows the standard R-package workflow: `devtools::load_all()`, `devtools::test()`,
+`devtools::check()`. Default development branch is `develop`. Note the README's **deprecated**
+lifecycle badge — confirm intent before large new features.
+
+> Heads-up: `traits.build` **Imports `austraits`** (it re-exports a few conversion helpers), so the
+> R-package install graph runs `traits.build → austraits` even though in the *data* pipeline
+> traits.build is upstream of austraits. Run traits.build's tests after touching those helpers.
+
+---
+
+## AusTraits family — cross-package context
+
+`traits.build` is part of the **AusTraits family** (a subset of the
+[`traitecoevo`](https://github.com/traitecoevo) org) — here, the generic workflow engine + relational
+data model/schema. Family-wide concerns are documented centrally in
+**[austraits-meta](https://github.com/traitecoevo/austraits-meta)** — don't restate them here, read
+them there:
+
+- **Start with [`AGENTS.md`](https://github.com/traitecoevo/austraits-meta/blob/main/AGENTS.md)** —
+  pipeline order, who owns what, dependency direction (incl. the reversed `traits.build → austraits`
+  edge), source-of-truth rules, cross-boundary artifacts, gotchas.
+- **[`dependencies.yml`](https://github.com/traitecoevo/austraits-meta/blob/main/dependencies.yml)** —
+  machine-readable package graph + cross-boundary artifacts.
+- **[`governance/`](https://github.com/traitecoevo/austraits-meta/tree/main/governance)** —
+  label taxonomy, board #9 conventions, release playbooks, triage.
+
+**Filing issues:** the whole family is tracked on one board,
+[AusTraits #9](https://github.com/orgs/traitecoevo/projects/9) (new issues auto-add to it). Follow
+the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta/blob/main/governance/issue-guide.md):
+pick one work-type label (`bug` / `task` / `epic`); Status and Priority are set on the board, not as
+labels.
+
+> austraits-meta is hand-maintained prose — a map, not ground truth. Verify specifics against the
+> actual repos.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,12 +16,27 @@ AusTraits project in 2023 (see Wenk et al. 2024, doi:10.1016/j.ecoinf.2024.10277
   function reference at <http://traitecoevo.github.io/traits.build/>.
 
 Dev follows the standard R-package workflow: `devtools::load_all()`, `devtools::test()`,
-`devtools::check()`. Default development branch is `develop`. Note the README's **deprecated**
-lifecycle badge — confirm intent before large new features.
+`devtools::check()`. Default development branch is `develop`.
 
-> Heads-up: `traits.build` **Imports `austraits`** (it re-exports a few conversion helpers), so the
-> R-package install graph runs `traits.build → austraits` even though in the *data* pipeline
-> traits.build is upstream of austraits. Run traits.build's tests after touching those helpers.
+> The README's **deprecated** lifecycle badge is a mistake, not a statement of intent — the package
+> is actively maintained and CRAN submission is a goal. Don't treat it as a reason to hold back on
+> new work. Fixing the badge is tracked in #225.
+
+**Test fixtures:** the nine `tests/testthat/examples/Test_2023_*` datasets are golden-file
+regression tests covering the whole output structure. Never hand-edit an expected file towards the
+output you observed — run `Rscript regenerate-examples.R` from `tests/testthat/` and read the diff.
+Every diff is either a fix you meant to make or a regression.
+
+> Heads-up: `traits.build` has `austraits` in **`Depends`** (it re-exports a few conversion
+> helpers), so the R-package install graph runs `traits.build → austraits` even though in the *data*
+> pipeline traits.build is upstream of austraits. Run traits.build's tests after touching those
+> helpers.
+>
+> `Depends` rather than `Imports` is deliberate and load-bearing, not an oversight: `custom_R_code`
+> in downstream `metadata.yml` files is evaluated against the search path, and ~1,240 call sites
+> across the 601 datasets in `austraits.build`, `ausinvertraits.build` and `AusFizz` call
+> dplyr/tidyr/stringr functions unqualified. Moving those packages to `Imports` breaks all of them.
+> See #225 before touching `DESCRIPTION`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -109,3 +109,15 @@ Australian Government's [National Collaborative Research Infrastructure Strategy
 
 This work received investment ([DP720](https://doi.org/10.47486/DP720)) from the ARDC.
 
+
+## AusTraits family
+
+`traits.build` is part of the **AusTraits family** of packages maintained by the
+[AusTraits](https://austraits.org) team. See **[austraits.org](https://austraits.org)** for the
+project, the data, and the people behind it.
+
+Contributing? Issues across the family are tracked on one board,
+[AusTraits #9](https://github.com/orgs/traitecoevo/projects/9), and new issues are auto-added. Please
+read the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta/blob/main/governance/issue-guide.md)
+in [`austraits-meta`](https://github.com/traitecoevo/austraits-meta) — the family's cross-package
+knowledge and governance hub — before filing.


### PR DESCRIPTION
`master` carries three commits that never reached `develop`. One of them, #217, was ported by
#229. These are the other two.

| Commit | Adds |
|---|---|
| #215 (28 Jun) | `.github/workflows/add-to-project.yml` — new issues auto-add to [board #9](https://github.com/orgs/traitecoevo/projects/9) |
| #214 (8 Jul) | `AGENTS.md`, `.claude/CLAUDE.md`, and an *AusTraits family* section in `README.md` |

Cherry-picked rather than merged: `master` is otherwise strictly behind `develop`, and merging
it would have tried to reintroduce the pre-#219–#222 state. All four files are new to
`develop`, and the only existing file touched is `README.md`, which takes a 12-line append at
the end.

### How this happened

Worth recording, because it will recur. Both PRs were merged into `master` rather than
`develop`, and so was #217 — the R-devel check fixes, which is why two R CMD check WARNINGs
survived on `develop` for three weeks after being fixed. `develop` is the default development
branch, but nothing enforces the base branch on a PR.

### Two corrections to AGENTS.md

Ported faithfully except for two statements that were wrong on arrival, both fixed in a
separate commit so the port itself stays reviewable:

**It told readers to "confirm intent before large new features" because of the README's
deprecated lifecycle badge.** That badge is a mistake, not a decision — the package is
actively maintained and CRAN submission is a goal, per #225. As written it is a standing brake
on exactly the work now planned, and it is the first thing an agent reading this file would
act on.

**It said traits.build `Imports` austraits. It is in `Depends`,** and the difference is the
whole point. `custom_R_code` in downstream `metadata.yml` is evaluated against the search
path, so ~1,240 unqualified dplyr/tidyr/stringr calls across the 601 datasets in
`austraits.build`, `ausinvertraits.build` and `AusFizz` work only because those packages are
attached. Describing it as `Imports` invites precisely the "tidy this up" change that breaks
all of them, so the note now says so explicitly and points at #225.

Also added a short note on the golden-file regeneration path from #230, since hand-editing
fixtures towards observed output is a failure this repo already has form for.

### Before merging

⚠️ #215's workflow needs the org secret `ADD_TO_PROJECT_PAT` (a token with Projects
read/write). It has been live on `master` since June, so this is presumably already set — but
worth confirming, since without it the workflow fails on every new issue. It triggers on
`issues: opened` only, so it will not run on this PR.

No code changes, so no effect on the test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)