### PR TITLE
Settle the licence as BSD-2 and use the DCF stub CRAN expects

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,17 +1,2 @@
-# Software 
-
-This R package is available for reuse under CC-BY license.  For details on access, usage and attribution please visit https://github.com/traitecoevo/traits.build with additional information available at https://doi.org/10.5281/zenodo.10373555.
-
-# Software licenced under the "BSD 2-clause license"
-
-Copyright (c) 2023, Daniel Falster
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+YEAR: 2023
+COPYRIGHT HOLDER: Daniel Falster


### PR DESCRIPTION
Kept as its own PR so the licence change has a clean audit trail rather than being buried among
bug fixes. Part of #225 Stage 1; no code, no test impact.

### The problem

`LICENCE` grants **two different licences, one after the other**:

1. a `# Software` section stating the package is *"available for reuse under CC-BY license"*, then
2. a `# Software licenced under the "BSD 2-clause license"` section carrying the full BSD text.

`DESCRIPTION` has said `License: BSD_2_clause + file LICENCE` the whole time, so the CC-BY
paragraph contradicts the field it sits behind. Anyone reading the file to work out their
obligations gets two incompatible answers.

Per #225 that paragraph dates from when the data lived alongside the code. The data now lives in
`austraits.build`, so the package is unambiguously BSD-2 — recorded there as decided.

### The change

For `BSD_2_clause + file LICENCE`, R supplies the licence text from its own template and expects
the file to be a **two-field DCF stub** filling in the placeholders, not a copy of the text. The
whole file becomes:

```
YEAR: 2023
COPYRIGHT HOLDER: Daniel Falster
```

**The BSD-2 terms are unchanged.** Year and copyright holder are carried over verbatim from the
notice being replaced — I did not update the year, since that is a substantive claim rather than a
formatting one. Say the word if it should read `2023-2026`.

### Effect

Clears the `License stub is invalid DCF` NOTE, one of the three remaining on a fresh-clone
`R CMD check`. With #229 and #230 in, that leaves two: the `ontology` directory (fixed in #237)
and the global-variable bindings (Stage 2).

Worth a second pair of eyes on one point: dropping the CC-BY grant narrows the terms for anyone
who relied on it between 2023 and now. My reading is that it was never operative for the software
— `DESCRIPTION` said BSD-2 throughout, and that is what package managers and CRAN read — but it is
your call, not mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)