### PR TITLE
Keep .claude and AGENTS.md out of the package tarball

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -28,3 +28,5 @@ _pkgdown.yml$
 ^Meta$
 ^planning$
 ^ontology$
+^\.claude$
+^AGENTS\.md$


### PR DESCRIPTION
My regression from #231, caught by a fresh-clone check after #237 merged.

#231 ported `AGENTS.md` and `.claude/CLAUDE.md` over from `master` without matching
`.Rbuildignore` entries, so both ship inside the installed package — and `.claude`, being hidden,
raises a check NOTE that was not there before:

```
* checking for hidden files and directories ... NOTE
Found the following hidden files and directories:
  .claude
These were most likely included in error.
```

Neither is any use to someone who has installed the package; they are contributor guidance.

### Effect

Fresh-clone `git clone && R CMD build && R CMD check` on current `develop` reports **2 NOTEs**.
This clears one, leaving only the `no visible binding for global variable` set, which is Stage 2
work in #225.

So after this: **0 errors, 0 warnings, 1 NOTE.** `error-on: "warning"` in `R-CMD-check.yml:58` can
be turned on whenever you like — it is no longer gated on anything.

No code change, no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)