### PR TITLE
Move the GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -39,7 +39,7 @@ jobs:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -6,7 +6,7 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      - uses: actions/add-to-project@v2
         with:
           project-url: https://github.com/orgs/traitecoevo/projects/9
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package


### PR DESCRIPTION
Follow-up to #242, which didn't go far enough.

## What happened

#242 bumped `actions/checkout` from v3 to v4, because v3 relies on Node 16, which is end-of-life. But **v4 relies on Node 20, which is also deprecated** — GitHub's runners are already force-upgrading it, and said so on every single job in the last `develop` run:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`

`v5` is the first release that targets Node 24 natively, so that's the real fix.

## Everything else that was also on Node 20

Once I checked the rest rather than just the one that complained:

| Action | Was | Now | Why that version |
|---|---|---|---|
| `actions/checkout` | v4 (node20) | **v5** | first node24 release |
| `actions/upload-artifact` | v4 (node20) | **v6** | first node24 release |
| `actions/add-to-project` | v1.0.2 (node20) | **v2** | first node24 release |

`upload-artifact` only runs on failure and `add-to-project` only on new issues, which is why neither had surfaced a warning yet. They would have.

`add-to-project@v2` is a major version bump, so I checked its interface rather than assuming: it takes the same `project-url` and `github-token` inputs. The major bump is the runtime change alone.

## Left alone deliberately

The four `r-lib/actions/*` steps need nothing. `setup-pandoc` and `setup-r` already target Node 24; `setup-r-dependencies` and `check-r-package` are composite actions with no JavaScript runtime of their own. Verified each rather than bumping on principle.

All three workflow files still parse.