### PR TITLE
Stop dataset_report() silently discarding a failed render

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,6 +42,7 @@ Imports:
 Suggests:
     furrr,
     remake,
+    forcats,
     leaflet,
     bibtex,
     knitr,

--- a/R/reports.R
+++ b/R/reports.R
@@ -13,29 +13,42 @@
 #' @param keep Keep intermediate Rmd file used?
 #'
 #' @rdname dataset_report
-#' @return Html file of the rendered report located in the specified output folder
+#' @return Invisibly, a logical named by `dataset_id`, `TRUE` where the report
+#'   was written. Reports are rendered as html files in `output_path`. A dataset
+#'   whose report fails to render warns and returns `FALSE` rather than aborting
+#'   the batch.
 #' @export
 dataset_report <- function(dataset_id, austraits, overwrite = FALSE,
                            output_path = "export/reports",
                            input_file = system.file("support", "report_dataset.Rmd", package = "traits.build"),
                            quiet = TRUE, keep = FALSE) {
 
-  for (d in dataset_id)
-    dataset_report_worker(
-      dataset_id = d,
-      austraits = austraits,
-      overwrite = overwrite,
-      output_path = output_path,
-      input_file = input_file,
-      quiet = quiet,
-      keep = keep
-    )
+  built <- vapply(
+    dataset_id,
+    function(d)
+      dataset_report_worker(
+        dataset_id = d,
+        austraits = austraits,
+        overwrite = overwrite,
+        output_path = output_path,
+        input_file = input_file,
+        quiet = quiet,
+        keep = keep
+      ),
+    logical(1)
+  )
+
+  invisible(built)
 }
 
 dataset_report_worker <- function(dataset_id, austraits, overwrite = FALSE,
                                   output_path = "export/reports",
                                   input_file = system.file("support", "report_dataset.Rmd", package = "traits.build"),
                                   quiet = TRUE, keep = FALSE) {
+
+  if (!file.exists(input_file)) {
+    stop("Report template not found: ", input_file, call. = FALSE)
+  }
 
   if (!file.exists(output_path)) {
     dir.create(output_path, FALSE, TRUE)
@@ -56,8 +69,13 @@ dataset_report_worker <- function(dataset_id, austraits, overwrite = FALSE,
 
     # Knit and render. Note, call render directly
     # in preference to knit, then render, as leaflet widget
-    # requires this to work
-    # Warning: result assigned but may not be used
+    # requires this to work.
+    #
+    # Rendering is allowed to fail without aborting, so that one bad dataset
+    # does not stop a batch of reports. It must still be reported: this was a
+    # bare `try()` whose result was discarded, so a failed render printed the
+    # success line anyway and the only trace was whatever `try()` happened to
+    # write to stderr (#244).
     result <- try(
       rmarkdown::render(
         input_Rmd,
@@ -67,17 +85,31 @@ dataset_report_worker <- function(dataset_id, austraits, overwrite = FALSE,
           dataset_id = dataset_id,
           austraits = austraits
         )
-      )
+      ),
+      silent = TRUE
     )
 
     # Remove temporary Rmd
     if (!keep)
       unlink(input_Rmd)
+
+    if (inherits(result, "try-error")) {
+      warning(
+        sprintf(
+          "Report for %s failed to build; no file written to %s.\n  %s",
+          dataset_id, output_html, conditionMessage(attr(result, "condition"))
+        ),
+        call. = FALSE
+      )
+      return(invisible(FALSE))
+    }
+
     message(" -> ", output_html, "\n")
   } else {
     message(sprintf(red("Report for %s") %+% red(" already exists -> %s\n"), blue(dataset_id), blue(output_html)))
   }
 
+  invisible(TRUE)
 }
 
 #' Format table with kable and default styling for html

--- a/man/dataset_report.Rd
+++ b/man/dataset_report.Rd
@@ -30,7 +30,10 @@ dataset_report(
 \item{keep}{Keep intermediate Rmd file used?}
 }
 \value{
-Html file of the rendered report located in the specified output folder
+Invisibly, a logical named by \code{dataset_id}, \code{TRUE} where the report
+was written. Reports are rendered as html files in \code{output_path}. A dataset
+whose report fails to render warns and returns \code{FALSE} rather than aborting
+the batch.
 }
 \description{
 Builds a detailed report for every dataset with a unique \code{dataset_id}, based on the template Rmd file provided.

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -842,11 +842,87 @@ testthat::test_that("`dataset_find_taxon` is working", {
 
 
 test_that("reports and plots are produced", {
+  # This used to assert only `expect_silent()`. `dataset_report()` renders in a
+  # child process, so a failure there writes to that process's stderr and
+  # `expect_silent()` cannot see it -- and `dataset_report()` swallowed the
+  # failure anyway. The test passed on a render that had errored, and asserted
+  # nothing about the report existing or containing anything (#244).
   expect_silent(suppressMessages(austraits <- remake::make("test_name")))
-  expect_silent(
+
+  # The report calls `austraits::plot_trait_distribution_beeswarm()`, which uses
+  # `forcats` -- declared in `austraits`' Suggests and used there unguarded, so
+  # without it the whole render fails and no file is written at all. Skipping
+  # rather than failing keeps an upstream packaging problem from reading as a
+  # regression here; `forcats` is in this package's Suggests so CI does run it.
+  skip_if_not_installed("forcats")
+
+  output_path <- withr::local_tempdir()
+  output_html <- file.path(output_path, "Test_2022.html")
+
+  expect_no_warning(
     suppressMessages(
-      dataset_report(dataset_id = "Test_2022", austraits = austraits, overwrite = TRUE)
+      built <- dataset_report(
+        dataset_id = "Test_2022", austraits = austraits,
+        output_path = output_path, overwrite = TRUE
+      )
     ))
+
+  # The report was actually written, not merely attempted
+  expect_true(file.exists(output_html))
+  expect_gt(file.size(output_html), 10000)
+
+  # ...and carries the sections it is built to carry, rather than being a
+  # rendered shell with the failing chunks silently dropped
+  report <- paste(readLines(output_html, warn = FALSE), collapse = "\n")
+  expect_match(report, "Test_2022", fixed = TRUE)
+  expect_no_match(report, "there is no package called", fixed = TRUE)
+})
+
+
+test_that("`dataset_report` reports a failed render instead of swallowing it", {
+  # A render failure used to be discarded by a bare `try()` whose result was
+  # never inspected, so the success line printed regardless and no file was
+  # written. In CI that is not hypothetical: `forcats` is absent there, the
+  # render failed on every run, and this test suite reported success (#244).
+  expect_silent(suppressMessages(austraits <- remake::make("test_name")))
+
+  output_path <- withr::local_tempdir()
+
+  # A template that parses but stops during knitting, so the failure happens
+  # where a real one does rather than in argument handling
+  template <- file.path(withr::local_tempdir(), "boom.Rmd")
+  writeLines(
+    c("---", "title: t", "output: html_document",
+      "params:", "    dataset_id: provide", "    austraits: provide", "---",
+      "", "```{r}", "stop('deliberate render failure')", "```"),
+    template
+  )
+
+  expect_warning(
+    suppressMessages(
+      built <- dataset_report(
+        dataset_id = "Test_2022", austraits = austraits,
+        output_path = output_path, overwrite = TRUE, input_file = template
+      )
+    ),
+    "failed to build"
+  )
+  expect_false(built)
+  expect_false(file.exists(file.path(output_path, "Test_2022.html")))
+})
+
+
+test_that("`dataset_report` rejects a missing template clearly", {
+  # `readLines()` on a nonexistent template gave "cannot open the connection",
+  # which names neither the file nor the argument
+  expect_silent(suppressMessages(austraits <- remake::make("test_name")))
+  expect_error(
+    dataset_report(
+      dataset_id = "Test_2022", austraits = austraits,
+      output_path = withr::local_tempdir(), input_file = "no-such-template.Rmd"
+    ),
+    "Report template not found"
+  )
 })
 
 testthat::test_that("`dataset_test` is working", {


### PR DESCRIPTION
Fixes #244, and the actual defect is worse than that issue guessed.

## What I found

`dataset_report_worker()` wrapped `rmarkdown::render()` in a bare `try()` and never inspected the result. The code even said so:

```r
# Warning: result assigned but may not be used
result <- try(rmarkdown::render(...))
```

So a failed render still printed `-> export/reports/<id>.html` and carried on.

**In CI this fires on every single run.** `forcats` is not installed there; the report calls `austraits::plot_trait_distribution_beeswarm()`, which uses `forcats` — declared in `austraits`' **Suggests** and used there **unguarded**. #244 wondered whether the report came out "degraded". It doesn't come out at all:

> `Report for Test_2022 failed to build; no file written to .../Test_2022.html`
> `  there is no package called 'forcats'`

**No html file, on every CI run, and the test suite reported success.** I verified this by rebuilding the package library with `forcats` removed and re-running — the same code that now warns previously printed the success line and left no file.

## Why the test never caught it

```r
test_that("reports and plots are produced", {
  expect_silent(suppressMessages(austraits <- remake::make("test_name")))
  expect_silent(suppressMessages(dataset_report(...)))
})
```

Two independent reasons, both worth naming:

1. The render runs in a **child process**, so its stderr was never visible to `expect_silent()` regardless.
2. Nothing asserted the report existed, or contained anything. Silence was the entire assertion — and it wasn't even measuring silence correctly.

Same shape as the `expect_output(dataset_test(...))` problem Stage 0 of #225 found.

## The fix

**Surface the failure.** Still non-fatal, so one bad dataset doesn't abort a batch of 411 — that's presumably why `try()` was there — but it now warns with the `dataset_id` and the underlying condition, and no longer prints a success line for a file that doesn't exist.

**Return something useful.** `dataset_report()` now returns, invisibly, a logical named by `dataset_id` saying which reports were actually written. It previously returned the value of a `for` loop, i.e. `NULL`, so nothing can depend on the old return.

**Validate `input_file` up front.** A missing template failed inside `readLines()` with `cannot open the connection`, naming neither the file nor the argument.

**Declare `forcats` in Suggests.** That is the honest description of what `dataset_report()` transitively needs, and it means CI actually exercises the report path instead of silently skipping it. The real fix — guarding a Suggests dependency — belongs upstream in `austraits`, and #244 stays open for that.

## Tests

The existing test now asserts the file is written, is non-trivial, and contains the `dataset_id`. It skips when `forcats` is genuinely absent, so an upstream packaging problem reads as a skip rather than a false regression. Two tests added for the failure paths — a template that parses but stops during knitting, and a missing template.

Verified in **both** environments, which is the point:

| | passing | failures | skips |
|---|---|---|---|
| with `forcats` (`test-setup.R`) | 244 | 0 | 0 |
| without `forcats` (`test-setup.R`) | 239 | 0 | 1 |
| full suite, with `forcats` | 879 | 0 | 1 (pre-existing `skip_on_cran`) |

879 is up from 869 on `develop`; the extra 10 are these assertions.

## Left for #244

Guarding the `forcats` use inside `austraits`, or promoting it out of Suggests there. Worth checking whether `austraits` uses any of its other suggested packages unguarded too — this one hid for as long as it did only because the failure was swallowed at both ends.