### PR TITLE
Reject an identifiers var_in that names a column not in the data

### DIFF
--- a/R/process.R
+++ b/R/process.R
@@ -99,6 +99,35 @@ dataset_process <- function(filename_data_raw,
   if ("identifiers" %in% names(metadata) && !all(is.na(metadata[["identifiers"]]))) {
     identifiers <-
       metadata[["identifiers"]] %>% austraits::convert_list_to_df2()
+
+    # A `var_in` naming a column that does not exist used to pass silently:
+    # `process_add_all_columns()` creates the missing column as all-NA, and the
+    # `!is.na(identifier_value)` filter below then drops every row, so the
+    # dataset lost its identifiers with no error, warning or empty-table hint
+    # (#232).
+    #
+    # Checked against `traits` rather than the raw csv header, because
+    # `custom_R_code` has already run above and legitimately creates these
+    # columns -- every dataset currently using this feature relies on that, so
+    # validating the raw header would reject all of them.
+    missing_var_in <- setdiff(identifiers$var_in, names(traits))
+
+    if (length(missing_var_in) > 0) {
+      stop(
+        sprintf(
+          paste0(
+            "Dataset %s declares identifiers with `var_in` naming %s not present in the data: %s.\n",
+            "  Available columns: %s\n",
+            "  If the column is meant to be created by `custom_R_code`, check that it runs and spells the name identically."
+          ),
+          dataset_id,
+          ifelse(length(missing_var_in) > 1, "columns", "a column"),
+          paste(missing_var_in, collapse = ", "),
+          paste(names(traits), collapse = ", ")
+        ),
+        call. = FALSE
+      )
+    }
   } else {
     identifiers <- list(
       "var_in",

--- a/tests/testthat/test-process.R
+++ b/tests/testthat/test-process.R
@@ -76,6 +76,60 @@ test_that("`process_format_identifiers` is working", {
 })
 
 
+test_that("a `var_in` naming a column that does not exist is rejected", {
+  # This used to pass silently: `process_add_all_columns()` creates the missing
+  # column as all-NA and the `!is.na(identifier_value)` filter then drops every
+  # row, so the dataset lost its identifiers with no error and an empty table
+  # (#232).
+  metadata_path <- file.path(withr::local_tempdir(), "metadata.yml")
+  metadata <- readLines("examples/Test_2023_1/metadata.yml")
+  metadata[grepl("^- var_in: herbarium_voucher$", metadata)] <-
+    "- var_in: herbarium_vouchers"
+  writeLines(metadata, metadata_path)
+
+  expect_error(
+    dataset_process(
+      "examples/Test_2023_1/data.csv",
+      dataset_configure(metadata_path, traits_definitions),
+      schema, resource_metadata, unit_conversions
+    ),
+    "herbarium_vouchers"
+  )
+})
+
+
+test_that("a `var_in` created by `custom_R_code` is still accepted", {
+  # The check has to run against the data as it stands after `custom_R_code`,
+  # not against the raw csv header. Every dataset in the three downstream
+  # repositories that uses identifiers creates its `var_in` column this way, so
+  # validating the raw header would reject all of them (#232).
+  metadata_path <- file.path(withr::local_tempdir(), "metadata.yml")
+  metadata <- readLines("examples/Test_2023_1/metadata.yml")
+
+  # Point `var_in` at a column absent from data.csv, then add it to the
+  # existing `custom_R_code` mutate so it exists by the time identifiers load
+  metadata[grepl("^- var_in: herbarium_voucher$", metadata)] <-
+    "- var_in: voucher_made_by_custom_code"
+  metadata[grepl("^\\s+LASA1000_dupe = LASA1000$", metadata)] <-
+    "        LASA1000_dupe = LASA1000,\n        voucher_made_by_custom_code = herbarium_voucher"
+  writeLines(metadata, metadata_path)
+
+  # Guard the premise: the column really is absent from the raw csv
+  expect_false(
+    "voucher_made_by_custom_code" %in% names(read_csv_char("examples/Test_2023_1/data.csv"))
+  )
+
+  expect_no_error(
+    built <- dataset_process(
+      "examples/Test_2023_1/data.csv",
+      dataset_configure(metadata_path, traits_definitions),
+      schema, resource_metadata, unit_conversions
+    )
+  )
+  expect_gt(nrow(built$identifiers), 0)
+})
+
+
 test_that("`write_plaintext` exports every table in the database", {
   # The table list used to be hardcoded and had `identifiers` missing from it
   # for the whole of 2.1.0, so exports silently dropped the release's headline


### PR DESCRIPTION
Fixes #232.

## The bug

A dataset declaring `identifiers` with a `var_in` naming a column that doesn't exist produced an **empty identifiers table and carried on**. Three steps, each individually reasonable:

1. `process_add_all_columns()` creates any missing column as all-NA.
2. The identifiers block pivots that column.
3. `filter(!is.na(identifier_value))` drops every row.

No error, no warning, no rows. The dataset just loses its identifiers.

`Test_2023_2` had declared `var_in: specimen` since it was created, with `specimen` never committed to its `data.csv` in any revision. Nobody noticed for the fixture's entire lifetime, because `identifiers.csv` wasn't among the tables compared until #230.

## The fix, and why the obvious version is wrong

The check validates `var_in` against `traits` **as it stands after `process_custom_code()` has run** — not against the raw `data.csv` header. That distinction is the entire fix.

`process_custom_code()` runs at `R/process.R:88-91`, before identifiers load at line 99. Every dataset that actually uses identifiers creates its `var_in` column in `custom_R_code`. So validating the raw header would reject **every real user of the feature** while catching nothing.

## Measured, not assumed

Scanned all 601 datasets across the three downstream repositories:

| Repo | datasets | declare `identifiers:` | declare a **real** block |
|---|---|---|---|
| `austraits.build` | 411 | 41 | **3** |
| `ausinvertraits.build` | 160 | 0 | 0 |
| `AusFizz` | 30 | 0 | 0 |

38 of the 41 are literally `identifiers: .na`, already short-circuited at `R/process.R:99`. So three datasets in 601 use this at all — and **all three name a `var_in` absent from the raw csv, and all three have it created by `custom_R_code`**:

| dataset_id | `var_in` | raw csv | after `custom_R_code` |
|---|---|---|---|
| `Gallagher_2015` | `Dean_Nicolle_tree_number` | no | yes |
| `Schulze_2006` | `voucher_specimen` | no | yes |
| `Schulze_2014` | `voucher_specimen` | no | yes |

**Post-custom-code validation: 0 of 601 break. Raw-header validation: 3 of 3 break.**

## Downstream gate, actually run

#241 flagged this as needing the three-database build gate rather than a judgement call. Rather than rely on the static scan, I ran the real builds against this branch:

```
Gallagher_2015   OK   identifiers rows = 681
Schulze_2006     OK   identifiers rows = 422
Schulze_2014     OK   identifiers rows = 209
```

All three still build, with identifiers populated. The other two repos don't use the feature, so their blast radius is genuinely zero rather than unmeasured — though both carry `identifiers` in their `config/metadata.yml` schemas, so they are in scope for the future.

## Tests

One per direction:

- A `var_in` naming a genuinely absent column **errors and names the column**, with the available columns listed and a pointer to `custom_R_code` as the likely cause.
- A `var_in` created by `custom_R_code` **still builds, with rows**. This one guards its own premise by first asserting the column really is missing from the raw csv, so it can't silently stop testing what it claims to.

Suite: 883 passing, up from 879 on `develop`, no failures.

## Note

The error is deliberately an error, not a warning — a silently empty identifiers table is data loss, and the measured blast radius is zero. #232 also suggests checking `contexts` and other `var_in`-style declarations for the same root cause; I have not done that here.