### PR TITLE
Compare whole characters in check_disallowed_chars, not bytes

### DIFF
--- a/R/test_functions.R
+++ b/R/test_functions.R
@@ -233,20 +233,36 @@ check_disallowed_chars <- function(x, exceptions = c("\u00c1\u00c5\u00c0\u00c2\u
 
   # Allow some utf8 characters, those with accents over letters for foreign names
   # List of codes is here: http://www.utf8-chartable.de/
-  allowed_bytes <- charToRaw(exceptions)
+  allowed_chars <- util_split_chars(exceptions)
 
-  # Returns one value per character rather than per byte, so that the positions
-  # line up with `colour_characters()`. Whether a character is disallowed is
-  # still decided byte by byte, exactly as before: it is allowed when every one
-  # of its bytes is either ASCII or appears somewhere in `exceptions`. That is
-  # looser than comparing whole characters -- a character assembled from bytes
-  # that all happen to occur in `exceptions` slips through -- but tightening it
-  # would change which real datasets pass, so it is left alone here.
+  # Compared whole character against whole character. This used to flatten
+  # `exceptions` into an unordered bag of bytes and allow a character when each
+  # of its bytes appeared *somewhere* in that bag, which let 1,671 code points
+  # through: the 49-character exception list yields only 47 distinct bytes, so
+  # anything reassembled from them passed. `ñ`, `É`, `Ø`, `º`, `≠`, `…`, `‰` and
+  # a non-breaking space were all silently accepted (#233).
+  #
+  # Returns one value per character, not per byte, so positions line up with
+  # `colour_characters()`.
   vapply(
     util_split_chars(x),
     function(char) {
       bytes <- charToRaw(char)
-      !all(bytes < 0x7F | bytes %in% allowed_bytes)
+
+      # ASCII is always allowed, whatever the exception list says
+      if (all(bytes < 0x7F)) {
+        return(FALSE)
+      }
+
+      # `util_split_chars()` falls back to splitting on bytes for input that is
+      # not valid UTF-8, so `char` can be a lone continuation byte. Those are
+      # exactly the mojibake this check exists to catch, and comparing them as
+      # strings is not meaningful, so treat them as disallowed.
+      if (!validUTF8(char)) {
+        return(TRUE)
+      }
+
+      !(char %in% allowed_chars)
     },
     logical(1),
     USE.NAMES = FALSE

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -76,3 +76,47 @@ test_that("`util_separate_and_sort` returns alphabetically sorted characters", {
 test_that("testing env is working", {
   expect_true(is_testing_env())
 })
+
+
+test_that("`check_disallowed_chars` compares whole characters, not bytes", {
+  # The exception list used to be flattened into an unordered bag of bytes, and a
+  # character was allowed when each of its bytes appeared *somewhere* in that
+  # bag. The 49-character list yields only 47 distinct bytes, so 1,671 code
+  # points reassembled from them slipped through (#233).
+  f <- check_disallowed_chars
+
+  # Every one of these was silently accepted. The first is an invisible
+  # non-breaking space; several are near-certainly mistyped ASCII -- `º` for
+  # `°`, `″` for `"`, `∼` for `~` -- so the check now surfaces real typos.
+  leaked <- c(" ", "ñ", "É", "Ø", "Ó", "º",
+              "≠", "…", "•", "†", "‰", "″",
+              "∼", "◦")
+  for (ch in leaked) {
+    expect_true(any(f(ch)), info = sprintf("U+%04X", utf8ToInt(ch)))
+  }
+
+  # Characters that were already caught must stay caught
+  for (ch in c("Ö", "€", "α", "中")) {
+    expect_true(any(f(ch)), info = sprintf("U+%04X", utf8ToInt(ch)))
+  }
+
+  # ...and every character in the exception list must still be allowed, or the
+  # check would start rejecting the accented names it exists to permit
+  allowed <- util_split_chars(eval(formals(f)$exceptions))
+  expect_false(any(vapply(allowed, function(ch) any(f(ch)), logical(1))))
+
+  # ASCII is allowed whatever the exception list says
+  expect_false(any(f("normal text 123 (a-b) [c] 45%")))
+
+  # One value per character, not per byte, so `colour_characters()` can index it
+  expect_length(f("abé"), 3L)
+
+  # Invalid UTF-8 is what this check exists to catch, so a stray Latin-1 byte
+  # must not pass. 45 of the 128 non-ASCII byte values used to.
+  expect_true(any(f(rawToChar(as.raw(c(0x32, 0x35, 0xb1, 0x31))))))
+
+  # The `is_data = TRUE` path passes `exceptions = ""`, which is ASCII-only.
+  # That was already equivalent to a character-wise check, so it must not move.
+  expect_true(any(f("é", exceptions = "")))
+  expect_false(any(f("abc", exceptions = "")))
+})


### PR DESCRIPTION
Closes #233 — but the scope is narrower than that issue states, and worth reading before merging, because 21 downstream datasets will newly report messages.

## The defect

`exceptions` was flattened into an **unordered bag of bytes**, and a character was allowed when each of its bytes appeared *somewhere* in that bag:

```r
allowed_bytes <- charToRaw(exceptions)
!all(bytes < 0x7F | bytes %in% allowed_bytes)
```

The 49-character exception list yields only **47 distinct byte values**, so anything reassembled from them passed — **1,671 code points** in total. All of these were silently accepted:

| | |
|---|---|
| letters | `ñ` `É` `Ø` `Ó` `º` |
| punctuation | `≠` `…` `•` `†` `‰` `″` `∼` `◦` |
| invisible | U+00A0 NO-BREAK SPACE |

Separately, `util_split_chars()` falls back to splitting on **bytes** for input that isn't valid UTF-8, and **45 of the 128 non-ASCII byte values passed on their own** — so the mojibake this check exists to catch was slipping through the fallback path too. Now disallowed.

ASCII is still always allowed, and every character in the exception list still passes, so the accented names the list exists to permit are unaffected.

## Two corrections to #233

**Only one of the two functions was broken.** `util_check_disallowed_chars()` (`R/process.R`, the **build** path) tests whether each byte is below `0x7F`. Every non-ASCII character has at least one byte at or above `0x80`, so it already flags all non-ASCII and was never leaky. Untouched here.

**Trait values were never affected.** `check_disallowed_chars()` is reached only from `test_expect_allowed_text()`, i.e. from `dataset_test`, and its `is_data = TRUE` call site passes `exceptions = ""` — which collapses to ASCII-only, already equivalent to a character-wise check. So:

- **No built database output changes.** This is a validator-only fix.
- No trait value changes verdict. The effect is on `metadata.yml` and column names.

That makes this materially lower-risk than the `cross-package` framing implies — nothing rebuilds, nothing fails to build.

## Blast radius: 93 occurrences, 21 datasets

Measured by running old logic against new over every `metadata.yml` in all three repos:

| repo | files | newly-flagged | datasets |
|---|---|---|---|
| `austraits.build` | 410 | 69 | 17 |
| `ausinvertraits.build` | 160 | 4 | 1 |
| `AusFizz` | 30 | 20 | 3 |

**Column names: 0 in all three.**

| character | count | almost certainly meant |
|---|---|---|
| U+00BA `º` MASCULINE ORDINAL | 34 | `°` degree sign |
| U+223C `∼` TILDE OPERATOR | 17 | `~` |
| U+2033 `″` DOUBLE PRIME | 9 | `"` |
| U+00F1 `ñ` | 8 | (legitimate) |
| U+2030 `‰` / U+0161 `š` | 6 each | |
| U+00D8 `Ø` | 5 | |
| U+25E6 `◦`, U+2020 `†`, U+00A0 NBSP, U+00D3 `Ó` | 1–2 each | |

So this mostly **surfaces real data-entry errors** rather than tightening a rule for its own sake.

Affected datasets: `Andrew_2022`, `Arnold_2021`, `Bourne_2017`, `Brodribb_2000`, `Bryant_2021`/`_2`/`_3`, `Canham_2023`, `Hanley_2002`, `Liu_2023`, `Mitchell_2008`, `Pfautsch_2016`, `SinghRamesh_2019`/`_2023`, `SmithMartin_2020`, `Tsakalos_2022`, `Zeppel_2008`, `Stanisic_2010`, `Cernusak_2011`, `Ellsworth_2015`, `Gimeno_2016`.

**What this means in practice:** those 21 datasets will report new `dataset_test` messages. Each is either a typo to fix in the dataset, or a character to add to the exception list. Nothing breaks in the meantime, and no database needs rebuilding.

## Also worth knowing

**13 `data.csv` files are not valid UTF-8** — austraits.build `Baker_2019`, `Dong_2017`, `Jordan_2015`, `Kew_2019_2`/`_3`/`_4`/`_5`, `NHNSW_2022`, `NTH_2022`, `Wenk_2022`, `Zieminska_2015`; ausinvertraits.build `Bentley_2010`, `Cassis_2010`. Their column names are clean, so the byte-fallback path is probably unreachable for them in practice, but I did not confirm that with a real build.

**If the check were ever extended to all `data.csv` cells** (it is not today) the picture changes sharply: 120,806 U+200D ZERO WIDTH JOINER occurrences in `NHNSW_2024`, `RBGV_2022`, `RBGV_2023`, plus 1,572 NBSP. Context for future scope decisions, not blast radius for this change.

## Tests

New test in `test-utils.R` pinning all four directions:

- the 14 characters that leaked are now flagged;
- the ones already caught stay caught;
- **every** character in the exception list still passes, so the check can't start rejecting the accented names it exists to permit;
- ASCII is untouched;
- one return value per character rather than per byte, so `colour_characters()` can still index it;
- a stray Latin-1 byte is flagged;
- and the `exceptions = ""` path is unchanged.

Verified with `NOT_CRAN=true`, since the Test_2023_9 snapshot test is `skip_on_cran()` and this change could have moved it: **908 passing, 0 failures, 0 skips, snapshot unchanged.**
