### PR TITLE
docs: add the citation files stranded on docs/family-usability

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -31,3 +31,4 @@ _pkgdown.yml$
 ^\.claude$
 ^AGENTS\.md$
 ^\.lintr$
+^CITATION\.cff$

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,67 @@
+# ------------------------------------------------
+# CITATION.cff file created with {cffr} R package
+# See also: https://docs.ropensci.org/cffr/
+# ------------------------------------------------
+ 
+cff-version: 1.2.0
+message: 'To cite package "traits.build" in publications use:'
+type: software
+license: BSD-2-Clause
+title: 'traits.build: A Workflow for Harmonising Trait Data from Diverse Sources into
+  a Documented Standard Structure'
+version: 2.1.0.900
+doi: 10.1016/j.ecoinf.2024.102773
+abstract: The `traits.build` package provides a workflow to harmonise trait data from
+  diverse sources. A description of the data model, workflow, and R package are presented
+  in Wenk et al, 2024, <https://doi.org/10.1016/j.ecoinf.2024.102773>. The code was
+  originally built to support AusTraits (see Falster et al 2021, <https://doi.org/10.1038/s41597-021-01006-6>,
+  <https://github.com/traitecoevo/austraits.build>) and has been generalised here
+  to support construction of other trait databases. For detailed instructions and
+  examples see <https://traitecoevo.github.io/traits.build-book/>.
+authors:
+- family-names: Falster
+  given-names: Daniel
+  email: daniel.falster@unsw.edu.au
+  orcid: https://orcid.org/0000-0002-9814-092X
+- family-names: Wenk
+  given-names: Elizabeth
+  orcid: https://orcid.org/0000-0001-5640-5910
+- family-names: Yang
+  given-names: Sophie
+  orcid: https://orcid.org/0000-0001-7328-345X
+- family-names: Kar
+  given-names: Fonti
+  orcid: https://orcid.org/0000-0002-2760-3974
+preferred-citation:
+  type: article
+  title: 'traits.build: A data model, workflow and R package for building harmonised
+    ecological trait databases'
+  authors:
+  - family-names: Wenk
+    given-names: Elizabeth
+    orcid: https://orcid.org/0000-0001-5640-5910
+  - family-names: Bal
+    given-names: Payal
+  - family-names: Coleman
+    given-names: David
+  - family-names: Gallagher
+    given-names: Rachael
+  - family-names: Yang
+    given-names: Sophie
+    orcid: https://orcid.org/0000-0001-7328-345X
+  - family-names: Falster
+    given-names: Daniel S.
+  journal: Ecological Informatics
+  year: '2024'
+  volume: '83'
+  doi: 10.1016/j.ecoinf.2024.102773
+  url: https://doi.org/10.1016/j.ecoinf.2024.102773
+  start: '102773'
+repository-code: https://github.com/traitecoevo/traits.build
+url: https://traitecoevo.github.io/traits.build/
+contact:
+- family-names: Falster
+  given-names: Daniel
+  email: daniel.falster@unsw.edu.au
+  orcid: https://orcid.org/0000-0002-9814-092X
+

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 - `metadata_add_contexts()`, `metadata_add_traits()` and `metadata_add_identifiers()` now guess column types from the same number of rows as the build (`guess_max = 100000`), so a sparse column can no longer be typed one way when metadata is written and another way when the database is built.
 - `metadata_add_source_doi()` now reports clearly that the optional `rcrossref` package is needed, and offers to install it in interactive sessions, instead of failing with `there is no package called 'rcrossref'` (#178).
 - Corrected the link to the AusTraits source repository, which had been misspelled `autraits.build` in `DESCRIPTION`, the package documentation and `NEWS.md`, and pointed at a URL that did not resolve. The Code of Conduct and reference website links in `README.md` were also dead or redirecting, and now resolve directly.
+- Added `CITATION.cff` and `inst/CITATION`, so `citation("traits.build")` and GitHub's "Cite this repository" widget both return the Wenk et al. (2024) paper. `CITATION.cff` is excluded from the package tarball via `.Rbuildignore`.
+- Removed a duplicated "AusTraits family" section from `README.md`, which had been added twice.
 
 # traits.build 2.1.0
 

--- a/README.md
+++ b/README.md
@@ -108,16 +108,3 @@ Australian Government's [National Collaborative Research Infrastructure Strategy
 (NCRIS).
 
 This work received investment ([DP720](https://doi.org/10.47486/DP720)) from the ARDC.
-
-
-## AusTraits family
-
-`traits.build` is part of the **AusTraits family** of packages maintained by the
-[AusTraits](https://austraits.org) team. See **[austraits.org](https://austraits.org)** for the
-project, the data, and the people behind it.
-
-Contributing? Issues across the family are tracked on one board,
-[AusTraits #9](https://github.com/orgs/traitecoevo/projects/9), and new issues are auto-added. Please
-read the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta/blob/main/governance/issue-guide.md)
-in [`austraits-meta`](https://github.com/traitecoevo/austraits-meta) — the family's cross-package
-knowledge and governance hub — before filing.

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,26 @@
+citHeader("To cite traits.build in publications use:")
+
+bibentry(
+  bibtype  = "Article",
+  title    = "traits.build: A data model, workflow and R package for building harmonised ecological trait databases",
+  author   = c(
+    person("Elizabeth", "Wenk"),
+    person("Payal", "Bal"),
+    person("David", "Coleman"),
+    person("Rachael", "Gallagher"),
+    person("Sophie", "Yang"),
+    person("Daniel S.", "Falster")
+  ),
+  journal  = "Ecological Informatics",
+  year     = "2024",
+  volume   = "83",
+  pages    = "102773",
+  doi      = "10.1016/j.ecoinf.2024.102773",
+  url      = "https://doi.org/10.1016/j.ecoinf.2024.102773",
+  textVersion = paste(
+    "Wenk, E., Bal, P., Coleman, D., Gallagher, R., Yang, S., Falster, D.S. (2024)",
+    "traits.build: A data model, workflow and R package for building harmonised",
+    "ecological trait databases. Ecological Informatics 83, 102773.",
+    "https://doi.org/10.1016/j.ecoinf.2024.102773"
+  )
+)


### PR DESCRIPTION
## Why

`CITATION.cff` and `inst/CITATION` were committed to `docs/family-usability` at 03:08 UTC on 8 July — one minute after that branch's PR #216 merged at 03:07. They were never picked up, and existed on **no other ref**: not `develop`, not `master`, not any open PR. As a result `citation("traits.build")` falls back to the auto-generated DESCRIPTION citation and GitHub's "Cite this repository" widget does not appear at all.

This recovers those two files so `docs/family-usability` can be deleted.

## What

- **`inst/CITATION`** — restored as-is; cites Wenk et al. (2024), *Ecological Informatics* 83: 102773. Verified it parses with `readCitationFile()`.
- **`CITATION.cff`** — **regenerated with `cffr` against the current `DESCRIPTION`** rather than restored verbatim. The stranded copy predated several DESCRIPTION fixes and still carried the misspelled `autraits.build` URL, an `http://` reference-site link, and the lowercased Title. Validates with `cffr::cff_validate()`. `preferred-citation` is picked up from `inst/CITATION`, so the GitHub widget cites the paper rather than the software.
- **`.Rbuildignore`** — added `^CITATION\.cff$`. It is not a standard top-level file, so `R CMD check` would otherwise raise a "Non-standard file/directory found at top level" NOTE. Confirmed via `R CMD build` that `CITATION.cff` is absent from the tarball while `inst/CITATION` still ships.
- **`README.md`** — removed a duplicated `## AusTraits family` section. The block appeared **twice, byte-identical**, after #216 and the austraits-meta pointer work each added it independently. The copy kept is the one immediately before Acknowledgements, matching the ordering in `austraits`, `APCalign`, `APD`, `austraits.build` and `austraits.portal`.

Nothing else from `docs/family-usability` is carried over — its `README.md` is now strictly older than develop's (it still has the `lifecycle-deprecated` badge that develop has since corrected to `stable`).

## Testing

Docs and metadata only; no R code touched.

- `readCitationFile("inst/CITATION")` parses and formats correctly
- `cffr::cff_validate("CITATION.cff")` → valid
- `R CMD build` → `CITATION.cff` excluded from tarball, `inst/CITATION` included

🤖 Generated with [Claude Code](https://claude.com/claude-code)