### PR TITLE
Finish the synonym replacement plumbing, and let curated substitutions win

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Depends:
     dplyr,
     lubridate,
     readr,
-    stringr,
+    stringr (>= 1.5.0),
     tidyr,
     austraits
 Imports:

--- a/R/process.R
+++ b/R/process.R
@@ -1655,7 +1655,8 @@ process_parse_data <- function(data, dataset_id, metadata, contexts, schema, ide
                 find = stringr::str_split(synonyms_string, ",")[[1]] %>%
                   stringr::str_trim() %>%
                   tolower(),
-                replace = trait_value
+                replace = trait_value,
+                trait_name = trait_name
               )
             } else {
               NULL

--- a/R/process.R
+++ b/R/process.R
@@ -139,7 +139,7 @@ dataset_process <- function(filename_data_raw,
   # Load and clean trait data
   traits <-
     traits %>%
-    process_parse_data(dataset_id, metadata, contexts, schema, identifiers)
+    process_parse_data(dataset_id, metadata, contexts, schema, identifiers, definitions)
 
   # Context ids needed to continue processing
   context_ids <- traits$context_ids
@@ -1408,7 +1408,7 @@ process_add_all_columns <- function(data, vars, add_error_column = TRUE) {
 #' substitutions and unique observation id added
 #' @importFrom dplyr select mutate filter arrange distinct case_when full_join everything any_of bind_cols
 #' @importFrom rlang .data
-process_parse_data <- function(data, dataset_id, metadata, contexts, schema, identifiers) {
+process_parse_data <- function(data, dataset_id, metadata, contexts, schema, identifiers, definitions) {
 
   # Get config data for dataset
   data_is_long_format <- metadata[["dataset"]][["data_is_long_format"]]
@@ -1639,6 +1639,60 @@ process_parse_data <- function(data, dataset_id, metadata, contexts, schema, ide
   if (length(i) > 0) {
     j <- !is.na(i)
     out[["trait_name"]][j] <- traits_table[["trait_name"]][i[j]]
+  }
+
+  # Apply automatic synonym replacements from traits.yml (definitions tibble)
+  if (!is.null(definitions) && length(definitions) > 0) {
+
+    # Create table of synonyms from the definitions table
+    synonym_table <-
+      purrr::imap_dfr(definitions, function(trait_definition, trait_name) {
+        if (!is.null(trait_definition$allowed_values_levels)) {
+          purrr::imap_dfr(trait_definition$allowed_values_levels, function(trait_value_description, trait_value) {
+            synonyms_string <- stringr::str_extract(trait_value_description, "(?<=\\(Synonyms,)[^)]+")
+            if (!is.na(synonyms_string)) {
+              tibble::tibble(
+                find = stringr::str_split(synonyms_string, ",")[[1]] %>%
+                  stringr::str_trim() %>%
+                  tolower(),
+                replace = trait_value
+              )
+            } else {
+              NULL
+            }
+          })
+        } else {
+          NULL
+        }
+      })
+
+    if (nrow(synonym_table) > 0) {
+      # For each trait by trait_value with synonyms, create replacement vectors.
+      # A vector is required, as there can be multiple synonyms per trait value.
+      # Synonyms are comma-delimited in the traits.yml and 
+      # are always words with hyphens and underscores but no spaces.
+      synonym_table <- synonym_table %>%
+        dplyr::mutate(pattern = stringr::str_c("\\b", stringr::str_escape(.data$find), "\\b")) %>%
+        dplyr::group_by(.data$trait_name) %>%
+        dplyr::summarise(
+          synonym_replacement_vec = list(purrr::set_names(replace, pattern)),
+          .groups = "drop"
+        )
+
+      # Implement trait value synonym substitutions, by joining the synonym replacement vectors,
+      # and using word by word searches to find matches.
+      # Remove column with replacement vectors at the end.
+      out <- out %>%
+        dplyr::left_join(synonym_table, by = "trait_name") %>%
+        dplyr::mutate(
+          value = purrr::map2_chr(
+            .data$value,
+            .data$synonym_replacement_vec,
+            function(v, rv) if (is.null(rv)) v else stringr::str_replace_all(v, rv)
+          )
+        ) %>%
+        dplyr::select(-"synonym_replacement_vec")
+    }
   }
 
   # Implement any value changes as per substitutions

--- a/R/process.R
+++ b/R/process.R
@@ -1404,6 +1404,9 @@ process_add_all_columns <- function(data, vars, add_error_column = TRUE) {
 #' [process_format_identifiers()]. Its `var_in` column names the columns of
 #' `data` holding identifier values, which are carried through so they can be
 #' split into the identifiers table once `observation_id` is set.
+#' @param definitions Trait definitions for this dataset -- the `elements` of the
+#' `traits.yml` schema, keyed by `trait_name`, as returned by [dataset_configure()].
+#' Used to apply database-wide trait value synonyms.
 #' @return Tibble in long format with AusTraits formatted trait names, trait
 #' substitutions and unique observation id added
 #' @importFrom dplyr select mutate filter arrange distinct case_when full_join everything any_of bind_cols
@@ -1641,61 +1644,6 @@ process_parse_data <- function(data, dataset_id, metadata, contexts, schema, ide
     out[["trait_name"]][j] <- traits_table[["trait_name"]][i[j]]
   }
 
-  # Apply automatic synonym replacements from traits.yml (definitions tibble)
-  if (!is.null(definitions) && length(definitions) > 0) {
-
-    # Create table of synonyms from the definitions table
-    synonym_table <-
-      purrr::imap_dfr(definitions, function(trait_definition, trait_name) {
-        if (!is.null(trait_definition$allowed_values_levels)) {
-          purrr::imap_dfr(trait_definition$allowed_values_levels, function(trait_value_description, trait_value) {
-            synonyms_string <- stringr::str_extract(trait_value_description, "(?<=\\(Synonyms,)[^)]+")
-            if (!is.na(synonyms_string)) {
-              tibble::tibble(
-                find = stringr::str_split(synonyms_string, ",")[[1]] %>%
-                  stringr::str_trim() %>%
-                  tolower(),
-                replace = trait_value,
-                trait_name = trait_name
-              )
-            } else {
-              NULL
-            }
-          })
-        } else {
-          NULL
-        }
-      })
-
-    if (nrow(synonym_table) > 0) {
-      # For each trait by trait_value with synonyms, create replacement vectors.
-      # A vector is required, as there can be multiple synonyms per trait value.
-      # Synonyms are comma-delimited in the traits.yml and 
-      # are always words with hyphens and underscores but no spaces.
-      synonym_table <- synonym_table %>%
-        dplyr::mutate(pattern = stringr::str_c("\\b", stringr::str_escape(.data$find), "\\b")) %>%
-        dplyr::group_by(.data$trait_name) %>%
-        dplyr::summarise(
-          synonym_replacement_vec = list(purrr::set_names(replace, pattern)),
-          .groups = "drop"
-        )
-
-      # Implement trait value synonym substitutions, by joining the synonym replacement vectors,
-      # and using word by word searches to find matches.
-      # Remove column with replacement vectors at the end.
-      out <- out %>%
-        dplyr::left_join(synonym_table, by = "trait_name") %>%
-        dplyr::mutate(
-          value = purrr::map2_chr(
-            .data$value,
-            .data$synonym_replacement_vec,
-            function(v, rv) if (is.null(rv)) v else stringr::str_replace_all(v, rv)
-          )
-        ) %>%
-        dplyr::select(-"synonym_replacement_vec")
-    }
-  }
-
   # Implement any value changes as per substitutions
   if (!is.na(metadata[["substitutions"]][1])) {
 
@@ -1718,10 +1666,105 @@ process_parse_data <- function(data, dataset_id, metadata, contexts, schema, ide
     }
   }
 
+  # Apply automatic trait value synonym replacements declared in `traits.yml`.
+  # This runs *after* substitutions, so a dataset's own curated substitution always
+  # wins over the database-wide synonym for the same value.
+  out <- process_replace_synonyms(out, definitions)
+
   list(
     traits = out,
     context_ids = context_ids
   )
+}
+
+
+#' Replace trait values with their preferred synonym
+#'
+#' Applies the database-wide trait value synonyms declared in `traits.yml`. A categorical
+#' trait value may list synonyms in its description using the convention
+#' `(Synonyms, first, second)`; every listed synonym found in the data is replaced by the
+#' value that declares it.
+#'
+#' Matching is on whole words, so a value that holds several space-delimited categorical
+#' values has each of them replaced independently, and a synonym occurring as part of a
+#' longer word is left alone. Values reaching this point are already lower-cased, which is
+#' why the synonyms are lower-cased too.
+#'
+#' Called from `process_parse_data()` *after* dataset substitutions have been applied, so
+#' that a curated, dataset-specific substitution takes precedence over the database-wide
+#' synonym for the same value.
+#'
+#' @param data Tibble with `trait_name` and `value` columns
+#' @param definitions Trait definitions for this dataset -- the `elements` of the
+#'   `traits.yml` schema, keyed by `trait_name`
+#'
+#' @return `data`, with synonyms in `value` replaced by their preferred value
+#' @importFrom rlang .data
+#' @noRd
+process_replace_synonyms <- function(data, definitions) {
+
+  if (is.null(definitions) || length(definitions) == 0) {
+    return(data)
+  }
+
+  # Collect the synonyms declared by each trait value's description
+  synonym_table <-
+    purrr::imap_dfr(definitions, function(trait_definition, trait_name) {
+      if (is.null(trait_definition[["allowed_values_levels"]])) {
+        return(NULL)
+      }
+      purrr::imap_dfr(
+        trait_definition[["allowed_values_levels"]],
+        function(trait_value_description, trait_value) {
+          # A value carrying no description at all yields a zero-length extract,
+          # so test the length before the value
+          synonyms <- stringr::str_extract(trait_value_description, "(?<=\\(Synonyms,)[^)]+")
+          if (length(synonyms) != 1 || is.na(synonyms)) {
+            return(NULL)
+          }
+          tibble::tibble(
+            find = stringr::str_split(synonyms, "[,;]")[[1]] %>%
+              stringr::str_trim() %>%
+              tolower(),
+            replace = trait_value,
+            trait_name = trait_name
+          )
+        }
+      )
+    })
+
+  if (nrow(synonym_table) == 0) {
+    return(data)
+  }
+
+  # One named replacement vector per trait, since a trait value may declare several
+  # synonyms and a trait several values. Patterns are escaped and word-bounded.
+  synonym_table <- synonym_table %>%
+    dplyr::filter(.data$find != "", .data$find != .data$replace) %>%
+    dplyr::mutate(
+      pattern = stringr::str_c("\\b", stringr::str_escape(.data$find), "\\b")
+    ) %>%
+    dplyr::group_by(.data$trait_name) %>%
+    dplyr::summarise(
+      replacements = list(purrr::set_names(.data$replace, .data$pattern)),
+      .groups = "drop"
+    )
+
+  # Replace one trait at a time: the traits declaring synonyms are few, while `data`
+  # can run to millions of rows, so this avoids touching rows that cannot match.
+  for (i in seq_len(nrow(synonym_table))) {
+    j <- which(data[["trait_name"]] == synonym_table[["trait_name"]][i])
+
+    if (length(j) > 0) {
+      data[["value"]][j] <-
+        stringr::str_replace_all(
+          data[["value"]][j],
+          synonym_table[["replacements"]][[i]]
+        )
+    }
+  }
+
+  data
 }
 
 

--- a/R/testdata.R
+++ b/R/testdata.R
@@ -718,7 +718,8 @@ dataset_test_worker <-
         ## Check that special characters do not make it into the data
         test_expect_no_error(
           parsed_data <- data %>%
-            process_parse_data(dataset_id, metadata, contexts, schema, identifiers),
+            process_parse_data(dataset_id, metadata, contexts, schema, identifiers,
+                               definitions[["elements"]]),
           info = sprintf("%s\t`process_parse_data`", red(dataset_id)))
 
         test_expect_allowed_text(

--- a/man/process_parse_data.Rd
+++ b/man/process_parse_data.Rd
@@ -4,7 +4,15 @@
 \alias{process_parse_data}
 \title{Process a single dataset}
 \usage{
-process_parse_data(data, dataset_id, metadata, contexts, schema, identifiers)
+process_parse_data(
+  data,
+  dataset_id,
+  metadata,
+  contexts,
+  schema,
+  identifiers,
+  definitions
+)
 }
 \arguments{
 \item{data}{Tibble or dataframe containing the study data}
@@ -21,6 +29,10 @@ process_parse_data(data, dataset_id, metadata, contexts, schema, identifiers)
 \code{\link[=process_format_identifiers]{process_format_identifiers()}}. Its \code{var_in} column names the columns of
 \code{data} holding identifier values, which are carried through so they can be
 split into the identifiers table once \code{observation_id} is set.}
+
+\item{definitions}{Trait definitions for this dataset -- the \code{elements} of the
+\code{traits.yml} schema, keyed by \code{trait_name}, as returned by \code{\link[=dataset_configure]{dataset_configure()}}.
+Used to apply database-wide trait value synonyms.}
 }
 \value{
 Tibble in long format with AusTraits formatted trait names, trait

--- a/tests/testthat/test-synonyms.R
+++ b/tests/testthat/test-synonyms.R
@@ -1,0 +1,191 @@
+## Tests for the database-wide trait value synonyms declared in `traits.yml`.
+##
+## A categorical trait value may list synonyms in its description with the
+## convention `(Synonyms, first, second)`; `process_replace_synonyms()` replaces
+## every listed synonym found in the data with the value that declares it.
+##
+## The quirks pinned below all occur in `austraits.build`'s real `config/traits.yml`
+## (197 synonyms across 27 traits), so they are not hypothetical: synonyms
+## separated by a semicolon rather than a comma, synonyms containing a space, and
+## a value that lists itself as one of its own synonyms.
+
+schema <- get_schema()
+resource_metadata <- get_schema("config/metadata.yml", "metadata")
+definitions <- get_schema("config/traits.yml", "traits")
+unit_conversions <- get_unit_conversions("config/unit_conversions.csv")
+
+# The `elements` of a traits.yml, keyed by trait_name. `process_replace_synonyms()`
+# takes this, *not* the whole schema object -- handing it the whole object dies on
+# the atomic `description` entry, which is what made #254 hard to read.
+test_definitions <- list(
+  plant_growth_form = list(
+    type = "categorical",
+    allowed_values_levels = list(
+      climber_herbaceous = "A herbaceous climber. (Synonyms, vine)",
+      climber_woody = "A woody climber. (Synonyms, liana)",
+      palmoid = "Palm-like habit. (Synonyms, rosette-tree, palm, grass-tree)",
+      tree = "A tree. No synonyms are declared for this value."
+    )
+  ),
+  seed_shape = list(
+    type = "categorical",
+    allowed_values_levels = list(
+      comma_shaped = "Comma shaped. (Synonyms, comma_shaped, falcate)",
+      ovoid_elongated = "Elongated ovoid. (Synonyms, clavate; obclavate)"
+    )
+  ),
+  leaf_area = list(type = "numeric")
+)
+
+trait_data <- function(trait_name, value) {
+  tibble::tibble(trait_name = trait_name, value = value)
+}
+
+replaced <- function(trait_name, value, definitions = test_definitions) {
+  process_replace_synonyms(trait_data(trait_name, value), definitions)[["value"]]
+}
+
+
+test_that("a declared synonym is replaced by the value that declares it", {
+  expect_equal(replaced("plant_growth_form", "vine"), "climber_herbaceous")
+  expect_equal(replaced("plant_growth_form", "liana"), "climber_woody")
+  expect_equal(replaced("seed_shape", "falcate"), "comma_shaped")
+})
+
+
+test_that("a synonym containing a hyphen is matched", {
+  expect_equal(replaced("plant_growth_form", "rosette-tree"), "palmoid")
+  expect_equal(replaced("plant_growth_form", "grass-tree"), "palmoid")
+})
+
+
+test_that("values that declare no synonyms are left alone", {
+  expect_equal(replaced("plant_growth_form", "tree"), "tree")
+  expect_equal(replaced("plant_growth_form", "shrub"), "shrub")
+  # a numeric trait has no allowed_values_levels at all
+  expect_equal(replaced("leaf_area", "12.4"), "12.4")
+})
+
+
+test_that("synonyms are scoped to the trait that declares them", {
+  # `falcate` is a seed_shape synonym only; plant_growth_form must not see it
+  expect_equal(replaced("plant_growth_form", "falcate"), "falcate")
+  expect_equal(replaced("seed_shape", "vine"), "vine")
+})
+
+
+test_that("each value of a multi-value cell is replaced independently", {
+  # Categorical values are space-delimited, so a cell may hold several of them
+  expect_equal(
+    replaced("plant_growth_form", "vine liana"),
+    "climber_herbaceous climber_woody"
+  )
+  expect_equal(
+    replaced("plant_growth_form", "tree vine shrub"),
+    "tree climber_herbaceous shrub"
+  )
+})
+
+
+test_that("a synonym occurring inside a longer word is not replaced", {
+  # Whole-word matching: without it, `\\bvine\\b` would corrupt these
+  expect_equal(replaced("plant_growth_form", "grapevine"), "grapevine")
+  expect_equal(replaced("plant_growth_form", "vineyard"), "vineyard")
+  expect_equal(replaced("seed_shape", "obclavate"), "ovoid_elongated")
+})
+
+
+test_that("synonyms separated by a semicolon are parsed, not treated as one", {
+  # austraits.build declares `(Synonyms, clavate; obclavate)`; splitting on the
+  # comma alone yielded the single unmatchable synonym "clavate; obclavate"
+  expect_equal(replaced("seed_shape", "clavate"), "ovoid_elongated")
+  expect_equal(replaced("seed_shape", "obclavate"), "ovoid_elongated")
+})
+
+
+test_that("a value listing itself as its own synonym is left unchanged", {
+  # `comma_shaped` declares `comma_shaped` among its synonyms; replacing a value
+  # with itself must be a no-op rather than an error
+  expect_equal(replaced("seed_shape", "comma_shaped"), "comma_shaped")
+})
+
+
+test_that("every row is replaced, and row order is preserved", {
+  expect_equal(
+    replaced("plant_growth_form", c("vine", "tree", "liana", "vine")),
+    c("climber_herbaceous", "tree", "climber_woody", "climber_herbaceous")
+  )
+})
+
+
+test_that("definitions carrying no synonyms are a no-op", {
+  data <- trait_data("plant_growth_form", c("vine", "tree"))
+  expect_equal(process_replace_synonyms(data, NULL), data)
+  expect_equal(process_replace_synonyms(data, list()), data)
+  expect_equal(
+    process_replace_synonyms(data, list(plant_growth_form = list(type = "numeric"))),
+    data
+  )
+  expect_equal(
+    process_replace_synonyms(
+      data,
+      list(plant_growth_form = list(
+        allowed_values_levels = list(tree = "A tree, with no synonyms declared.")
+      ))
+    ),
+    data
+  )
+})
+
+
+test_that("a trait value carrying no description is tolerated", {
+  # None of the three databases has one today, but a curator adding a value with
+  # no description would otherwise abort the build with "argument is of length zero"
+  data <- trait_data("plant_growth_form", c("vine", "tree"))
+  expect_no_error(
+    result <- process_replace_synonyms(
+      data,
+      list(plant_growth_form = list(
+        allowed_values_levels = list(
+          tree = NULL,
+          climber_herbaceous = "A herbaceous climber. (Synonyms, vine)"
+        )
+      ))
+    )
+  )
+  expect_equal(result[["value"]], c("climber_herbaceous", "tree"))
+})
+
+
+test_that("a dataset substitution is applied before the database-wide synonyms", {
+  # Regression test for the ordering. The synonym pass used to run *first*, which
+  # silently pre-empted the dataset's own curated substitutions: measured across
+  # austraits.build, 196 substitution entries in 21 datasets had a `find` that a
+  # synonym had already rewritten, so they never matched.
+  #
+  # Here `climber` is a plain value in the raw data. Substituting it to `vine`
+  # -- which the fixture declares as a synonym of `climber_herbaceous` -- only
+  # resolves to `climber_herbaceous` if substitutions run first. Under the old
+  # order the value stays `vine`, which is not an allowed level, so the row is
+  # dropped into `excluded_data` instead.
+  config <- dataset_configure("examples/Test_2023_1/metadata.yml", definitions)
+
+  config[["metadata"]][["substitutions"]] <-
+    c(config[["metadata"]][["substitutions"]],
+      list(list(trait_name = "plant_growth_form", find = "climber", replace = "vine")))
+
+  built <- dataset_process("examples/Test_2023_1/data.csv", config, schema,
+                           resource_metadata, unit_conversions)
+
+  growth_form <- built[["traits"]] %>%
+    dplyr::filter(.data$trait_name == "plant_growth_form")
+
+  expect_true("climber_herbaceous" %in% growth_form[["value"]])
+  expect_false("climber" %in% growth_form[["value"]])
+
+  # the unresolved synonym must not leak through, nor be excluded as unsupported
+  excluded <- built[["excluded_data"]] %>%
+    dplyr::filter(.data$trait_name == "plant_growth_form")
+  expect_false("vine" %in% excluded[["value"]])
+  expect_false("vine" %in% growth_form[["value"]])
+})


### PR DESCRIPTION
Rebase of `adding-synonym-automated-replacements` onto `develop`, plus the fix for #254 and tests for the feature.

@ehwenk — the feature works; this finishes the plumbing and changes one thing you'll want to weigh in on (the ordering, below). Your two commits are preserved as-is; everything I changed is in the third commit. I opened this as a new branch rather than force-pushing yours, so `adding-synonym-automated-replacements` is untouched.

Closes #254.

## Why #254 happened

`process_parse_data()` gained a `definitions` argument, and `dataset_process()` was updated to pass it — but `dataset_test_worker()` was not. So every dataset built correctly and then failed its own test. It only ever reproduced on that branch; `develop` was never affected.

The reason it isn't a one-word fix: `definitions` means two different things here. `dataset_test()` holds the **whole** traits.yml object (`description`, `type`, `elements`), while the `process_*` functions expect the inner **`elements`** list keyed by `trait_name` (that's what `dataset_configure()` hands to `dataset_process()`). Passing the whole object doesn't degrade gracefully — it dies on the atomic `description` entry with `$ operator is invalid for atomic vectors`. So the call passes `definitions[["elements"]]`.

I deliberately did **not** give `definitions` a default. With `= NULL` a caller that forgets it would silently skip synonym replacement, so `dataset_test()` would validate data the build never produces. A loud error is the better failure. The existing `test-dataset-test.R` already covers this — I confirmed it fails with the exact #254 message when the fix is reverted, so CI would have caught it. The branch predated that test file, which is why it slipped through.

## The one behaviour change: substitutions now run before synonyms

This is the change worth your review. The synonym pass ran *before* dataset `substitutions`; it now runs *after*.

Because substitutions match on whole-value equality, a synonym that had already rewritten a value meant the curator's substitution could never match — silently, with no warning. Measured against all 411 `austraits.build` datasets:

| | count |
|---|---|
| Substitution entries silently pre-empted | **196**, in 21 datasets |
| ...where curator and synonym disagree outright | 5, in 5 datasets |
| Total substitution entries scanned | 3,990, in 193 datasets |

The disagreements are the clearest cases — the curator's considered value was being discarded in favour of the database-wide default:

| trait | value | curator says | synonym says |
|---|---|---|---|
| `plant_growth_form` | `vine` | `climber_woody` | `climber_herbaceous` |
| `bud_bank_location` | `rootstock` | `bud-bearing_root` / `basal_buds` | `basal_stem_buds` |
| `leaf_shape` | `cuneate` | `na` | `obtriangular` |

The other 191 are whole-value substitutions containing a synonym as a word — e.g. `dispersal_syndrome: "wind water"` was rewritten to `"anemochory hydrochory"` before the substitution matching `"wind water"` could fire.

Running substitutions first gives dataset-specific curation precedence over the database-wide default, and synonyms still resolve anything left over — including values a substitution *produces*. If you'd rather synonyms won, say so and I'll revert it, but the 196 silent no-ops look like the wrong default.

## Other changes

- **Extracted `process_replace_synonyms()`** so the pass is testable on its own, rather than being 50 lines inside an already-long function.
- **Replace one trait at a time** instead of joining a list column onto every row. 27 austraits traits declare synonyms while the long-format data runs to millions of rows, and the row-wise `map2_chr()` walked all of them: **2.7s vs 0.03s per 200k rows**. This also matches the `for`/`which` idiom the substitutions block right above it already uses.
- **Split synonyms on `;` as well as `,`.** `austraits.build` declares `(Synonyms, clavate; obclavate)`, which comma-only splitting turned into the single unmatchable synonym `"clavate; obclavate"`.
- **Skip a value that lists itself as its own synonym** (`seed_shape: comma-shaped` does).
- **Tolerate a value with no description** — that aborted with `argument is of length zero`. Latent, not live: 0 occurrences across all three databases today.
- `@param definitions` documented; `man/process_parse_data.Rd` hand-edited rather than roxygenised, since the installed roxygen is 8.0.0 and that migration is separate work on `chore/roxygen-8`.
- `stringr (>= 1.5.0)` in `Depends`, for `str_escape()`.

## Two things for you, not fixed here

1. **13 synonyms in `austraits.build/config/traits.yml` contain a space**, which the code comment said couldn't happen. Two look like APD source defects rather than real synonyms: `sickle-shaped scimitar-shaped` (seed_shape) reads as two synonyms that lost their separator, and `clavate; obclavate` is the semicolon case above. Worth a look upstream in APD, since that's where these are generated.
2. **The `(Synonyms, ...)` convention isn't documented** in the book or the schema — it's currently only discoverable by reading `process_replace_synonyms()`.

## Testing

- `tests/testthat/test-synonyms.R`, 28 assertions: replacement, hyphenated and semicolon-separated synonyms, trait scoping, multi-value cells, whole-word matching (`grapevine` untouched), no-op cases, and the substitution-precedence regression. I checked the precedence test fails under the old order.
- Full suite **937 passing, 0 failures, 0 skips** with `NOT_CRAN=true` (so the `Test_2023_9` snapshot actually runs).
- The nine golden-file examples are **unchanged** — no fixture output moves.
- CI-equivalent check `Status: OK`: `_R_CHECK_CRAN_INCOMING_=false _R_CHECK_FORCE_SUGGESTS_=false NOT_CRAN=true R CMD check --no-manual --as-cran`.

**Not run: the downstream build gate.** This changes trait values in `austraits.build` output, so it wants a rebuild-and-diff there before merge. `ausinvertraits.build` and `AusFizz` declare no synonyms at all, so they're inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
