### PR TITLE
Add a PR template and the commit-message pointer

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+Replace this line with why the change was needed — one short paragraph.
+
+Replace this line with what changed in observable behaviour — one short paragraph. If this moves
+published trait values, say how many records or taxa moved and in which direction, on one line.
+
+Closes #
+
+Delete this paragraph before merging. Keep the title ≤50 characters and this body ≤10 lines: it
+becomes the permanent commit message. Working detail — what you tried, benchmarks, test counts,
+rejected alternatives, remaining work — goes in the first comment on this PR, not here.
+Convention: https://github.com/traitecoevo/austraits-meta/blob/master/governance/commit-messages.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,5 +90,11 @@ the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta/blob
 pick one work-type label (`bug` / `task` / `epic`); Status and Priority are set on the board, not as
 labels.
 
+**Commit messages:** every family repo squash-merges, so the **PR title and body become the permanent
+commit message**. Keep the subject ≤50 characters as typed and the body ≤10 lines; put the working
+detail — what you tried, benchmarks, test counts, rejected alternatives — in the **first PR comment**
+instead. Full convention:
+[`commit-messages.md`](https://github.com/traitecoevo/austraits-meta/blob/master/governance/commit-messages.md).
+
 > austraits-meta is hand-maintained prose — a map, not ground truth. Verify specifics against the
 > actual repos.


### PR DESCRIPTION
Every family repo squash-merges, so a PR's title and body become the
permanent commit message. This repo has among the family's longest
commit bodies — a median of 398 words per squash merge, against 28-107
in most family repos — because descriptions were used to show working.

Adds `.github/PULL_REQUEST_TEMPLATE.md` and a "Commit messages" bullet
in `AGENTS.md` pointing at austraits-meta's convention. The template
uses prose placeholders rather than HTML comments, which a PR body
carries into the commit intact.
